### PR TITLE
Add notebook kernel management and state retrieval functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 <p align="center">
-  <a href="https://fastdash.app/"><img src="https://storage.googleapis.com/deepagents/cover.png" alt="Fast Dash" width=600></a>
+  <img src="https://storage.googleapis.com/deepagents/cover.png" alt="DeepAgent Lab" width=600>
 </p>
+
 <p align="center">
     <em>Bring LangChain agents into your JupyterLab workflow</em>
-</p>
-
-
 </p>
 
 ---
@@ -16,6 +14,12 @@
 ---
 
 A JupyterLab extension to allow **your** LangChain agents access to JuputerLab notebooks and files, enabling natural language interactions with your data science projects **directly from JupyterLab**.
+
+<p align="center">
+  <img src="https://storage.googleapis.com/deepagents/screenshot1.png" alt="DeepAgent Lab Demo" width=800>
+</p>
+
+Watch the full demo video here: [https://www.youtube.com/watch?v=vGA2vzMSQzo](https://www.youtube.com/watch?v=vGA2vzMSQzo)
 
 ## Features
 

--- a/deepagent_lab/agent.py
+++ b/deepagent_lab/agent.py
@@ -47,8 +47,63 @@ MODEL_TEMPERATURE = config.MODEL_TEMPERATURE
 
 # === Tool Definitions ===
 
+def start_notebook_kernel(notebook_path: str) -> str:
+    """
+    Start a new kernel for a notebook via Jupyter Server API.
+
+    Creates a new session with a running kernel for the specified notebook.
+    If a session already exists for this notebook, returns the existing kernel ID.
+
+    Args:
+        notebook_path: Path to the notebook file (relative to server root).
+
+    Returns:
+        The kernel ID string for the running kernel.
+
+    Raises:
+        ValueError: If unable to connect to the Jupyter server or create a session.
+    """
+    # First check if a kernel is already running
+    try:
+        return get_notebook_kernel_id(notebook_path)
+    except ValueError:
+        pass  # No existing kernel, continue to start a new one
+
+    # Start a new session with a kernel
+    response = requests.post(
+        f'{JUPYTER_SERVER_URL}/api/sessions',
+        headers={'Authorization': f'token {JUPYTER_TOKEN}'} if JUPYTER_TOKEN else {},
+        json={
+            'path': notebook_path,
+            'type': 'notebook',
+            'kernel': {'name': 'python3'}
+        }
+    )
+
+    if response.status_code not in [200, 201]:
+        raise ValueError(f"Failed to start kernel for {notebook_path}: {response.text}")
+
+    session = response.json()
+    return session['kernel']['id']
+
+
 def get_notebook_kernel_id(notebook_path: str) -> str:
-    """Get kernel ID for a running notebook via Jupyter Server API."""
+    """
+    Get the kernel ID for a running notebook via Jupyter Server API.
+
+    Queries the Jupyter server's /api/sessions endpoint to find the active kernel
+    associated with the specified notebook path.
+
+    Args:
+        notebook_path: Path to the notebook file (can be absolute or relative to server root).
+
+    Returns:
+        The kernel ID string for the running kernel.
+
+    Raises:
+        ValueError: If unable to connect to the Jupyter server or no running kernel
+                   is found for the specified notebook.
+    """
     response = requests.get(
         f'{JUPYTER_SERVER_URL}/api/sessions',
         headers={'Authorization': f'token {JUPYTER_TOKEN}'} if JUPYTER_TOKEN else {}
@@ -56,17 +111,106 @@ def get_notebook_kernel_id(notebook_path: str) -> str:
 
     if response.status_code != 200:
         raise ValueError(f"Cannot connect to Jupyter server at {JUPYTER_SERVER_URL}")
-    
+
     sessions = response.json()
     for session in sessions:
         if notebook_path in session['notebook']['path']:
             return session['kernel']['id']
-    
+
     raise ValueError(f"No running kernel found for {notebook_path}")
 
 
+def get_notebook_state(notebook_path: str) -> str:
+    """
+    Get the current state of a notebook including cell information.
+
+    Reads the notebook and provides a summary of its current state, including
+    the total number of cells, which cells have been executed, and the recommended
+    index for inserting the next cell.
+
+    Args:
+        notebook_path: Path to the notebook file. Leading slashes are
+                      automatically stripped.
+
+    Returns:
+        A formatted string containing:
+        - Total number of cells
+        - List of executed cells (with their execution counts)
+        - List of unexecuted code cells
+        - Recommended next insertion index (typically at the end)
+        - Summary of cell types
+
+    Example return:
+        Notebook state for example.ipynb:
+        - Total cells: 5
+        - Code cells: 4
+        - Markdown cells: 1
+        - Executed cells: [0] (count: 1), [1] (count: 2)
+        - Unexecuted cells: [2], [3]
+        - Next insertion index: 5 (end of notebook)
+    """
+    notebook_path = notebook_path.strip("/")
+
+    try:
+        nb = nbformat.read(notebook_path, as_version=4)
+    except FileNotFoundError:
+        return f"Error: Notebook not found at {notebook_path}"
+
+    total_cells = len(nb.cells)
+    code_cells = sum(1 for cell in nb.cells if cell.cell_type == 'code')
+    markdown_cells = sum(1 for cell in nb.cells if cell.cell_type == 'markdown')
+
+    executed_cells = []
+    unexecuted_cells = []
+
+    for idx, cell in enumerate(nb.cells):
+        if cell.cell_type == 'code':
+            if cell.execution_count is not None:
+                executed_cells.append(f"[{idx}] (count: {cell.execution_count})")
+            else:
+                unexecuted_cells.append(f"[{idx}]")
+
+    # Next insertion index is typically at the end
+    next_index = total_cells
+
+    # Build the state summary
+    state_lines = [
+        f"Notebook state for {notebook_path}:",
+        f"- Total cells: {total_cells}",
+        f"- Code cells: {code_cells}",
+        f"- Markdown cells: {markdown_cells}",
+    ]
+
+    if executed_cells:
+        state_lines.append(f"- Executed cells: {', '.join(executed_cells)}")
+    else:
+        state_lines.append("- Executed cells: None")
+
+    if unexecuted_cells:
+        state_lines.append(f"- Unexecuted code cells: {', '.join(unexecuted_cells)}")
+    else:
+        state_lines.append("- Unexecuted code cells: None")
+
+    state_lines.append(f"- Next insertion index: {next_index} (end of notebook)")
+
+    return '\n'.join(state_lines)
+
+
 def create_notebook(notebook_path: str) -> str:
-    """Create a new empty Jupyter notebook file and return confirmation."""
+    """
+    Create a new empty Jupyter notebook file.
+
+    Initializes a new notebook with nbformat v4 specification and writes it to the
+    specified path. The notebook will contain no cells initially.
+
+    Args:
+        notebook_path: Path where the new notebook should be created. Leading slashes
+                      are automatically stripped.
+
+    Returns:
+        A confirmation message indicating the notebook was created successfully,
+        including the path to the new file.
+    """
 
     notebook_path = notebook_path.strip("/")
     nb = nbformat.v4.new_notebook()
@@ -77,9 +221,27 @@ def create_notebook(notebook_path: str) -> str:
 def insert_code_cell(
     code: Annotated[str, "Python code for the cell"],
     notebook_path: Annotated[str, "Notebook filename"],
-    position: Annotated[int, "Index to insert cell at (-1 for append)"] = -1
+    cell_idx: Annotated[int, "Index to insert cell at (-1 for append)"] = -1
 ) -> str:
-    """Insert a new code cell into the notebook via Jupyter Server API."""
+    """
+    Insert a new code cell into an existing notebook.
+
+    Creates a new code cell with the specified source code and inserts it at the
+    given position in the notebook. The notebook is saved either via the Jupyter
+    Server API (to maintain scroll position) or directly to the filesystem if the
+    API save fails.
+
+    Args:
+        code: The Python source code to insert into the new cell.
+        notebook_path: Path to the target notebook file. Leading slashes are
+                      automatically stripped.
+        cell_idx: Zero-based index where the cell should be inserted. Use -1 to
+                 append the cell at the end of the notebook. Defaults to -1.
+
+    Returns:
+        A confirmation message indicating the cell was inserted successfully,
+        including the final index position and notebook path.
+    """
 
     notebook_path = notebook_path.strip("/")
 
@@ -88,12 +250,12 @@ def insert_code_cell(
     new_cell = nbformat.v4.new_code_cell(source=code)
     # new_cell.metadata['jupyter'] = {'source_hidden': True}
 
-    if position == -1:
+    if cell_idx == -1:
         nb.cells.append(new_cell)
         cell_idx = len(nb.cells) - 1
     else:
-        nb.cells.insert(position, new_cell)
-        cell_idx = position
+        nb.cells.insert(cell_idx, new_cell)
+        cell_idx = cell_idx
 
     # Save via API to maintain scroll position
     save_response = requests.put(
@@ -117,7 +279,26 @@ def modify_cell(
     cell_index: Annotated[int, "Index of cell to modify"],
     new_code: Annotated[str, "New code (empty string to delete cell)"]
 ) -> str:
-    """Modify or delete an existing cell in the notebook via Jupyter Server API."""
+    """
+    Modify or delete an existing code cell in a notebook.
+
+    Updates the source code of the cell at the specified index. If an empty string
+    is provided as new_code, the cell is deleted instead. When modifying a cell,
+    its outputs and execution count are cleared. The notebook is saved either via
+    the Jupyter Server API (to maintain scroll position) or directly to the
+    filesystem if the API save fails.
+
+    Args:
+        notebook_path: Path to the target notebook file. Leading slashes are
+                      automatically stripped.
+        cell_index: Zero-based index of the cell to modify or delete.
+        new_code: The new Python source code for the cell. Pass an empty string ("")
+                 to delete the cell instead of modifying it.
+
+    Returns:
+        A confirmation message indicating success, or an error message if the cell
+        index is out of range or the cell is not a code cell.
+    """
 
     notebook_path = notebook_path.strip("/")
 
@@ -161,9 +342,32 @@ def modify_cell(
 
 def execute_cell(
     notebook_path: Annotated[str, "Notebook filename"],
-    cell_index: Annotated[int, "Index of cell to execute"]
+    cell_index: Annotated[int, "Index of cell to execute"] = -1
 ) -> str:
-    """Execute a cell in the notebook kernel and update outputs in the file."""
+    """
+    Execute a code cell in the notebook's kernel and update its outputs.
+
+    Automatically starts a kernel for the notebook if one isn't already running,
+    then connects to it, executes the specified cell, collects all outputs (stdout,
+    stderr, display data, errors), and updates the cell's execution count and outputs
+    in the notebook file. The notebook is saved either via the Jupyter Server API
+    (to maintain scroll position) or directly to the filesystem if the API save fails.
+
+    Args:
+        notebook_path: Path to the target notebook file. Leading slashes are
+                      automatically stripped.
+        cell_index: Zero-based index of the cell to execute. Defaults to -1 (last cell).
+
+    Returns:
+        A message containing the execution count and a summary of all outputs,
+        including stream outputs (stdout/stderr), execution results, display data,
+        and error tracebacks. Returns "(no output)" if the cell produces no output.
+
+    Note:
+        The kernel is automatically started via the Jupyter Server API if not already
+        running. The kernel client is cached for reuse across multiple executions of
+        the same notebook.
+    """
 
     notebook_path = notebook_path.strip("/")
 
@@ -174,9 +378,9 @@ def execute_cell(
     if cell.cell_type != 'code':
         return f"Cell {cell_index} is not a code cell"
 
-    # Connect to kernel
+    # Connect to kernel (start one if it doesn't exist)
     if notebook_path not in kernel_clients:
-        kernel_id = get_notebook_kernel_id(notebook_path)
+        kernel_id = start_notebook_kernel(notebook_path)
         connection_file = find_connection_file(kernel_id)
         client = BlockingKernelClient()
         client.load_connection_file(connection_file)
@@ -261,12 +465,14 @@ system_prompt = """You're a JupyterLab assistant. Use the provided tools to mani
 - If necessary, write code to answer user questions.
 - Always write the requested code into a Jupyter notebook using the tools described below.
 - You may choose to create a temporary Jupyter notebook file for intermediate steps.
+- MOST IMPORTANTLY, ALWAYS execute the code cells right after inserting them and then modify to ensure they work correctly.
 
 # Tools for writing Jupyter Notebooks:
+- `get_notebook_state(notebook_path: str) -> str`: Gets the current state of a notebook, including total cells, executed/unexecuted cells, and the recommended next insertion index.
 - `create_notebook(notebook_path: str) -> str`: Creates a new empty Jupyter notebook file at the specified path. Returns a confirmation message.
 - `insert_code_cell(code: str, notebook_path: str, position: int = -1) -> str`: Inserts a new code cell with the given code into the specified notebook at the given position (default is to append at the end). Returns the index of the inserted cell.
 - `modify_cell(notebook_path: str, cell_index: int, new_code: str) -> str`: Modifies the code of the cell at the specified index in the notebook. If `new_code` is an empty string, deletes the cell. Returns a confirmation message.
-- `execute_cell(notebook_path: str, cell_index: int) -> str`: Executes the code cell at the specified index in the notebook and updates its outputs. Returns the execution result or error message.
+- `execute_cell(notebook_path: str, cell_index: int) -> str`: Executes the code cell at the specified index in the notebook and updates its outputs. Returns the execution result or error message. Automatically starts a kernel if needed.
 
 # Examples:
 User: Please create a new notebook "example.ipynb" and add a code cell that prints "Hello, World!", then execute it.
@@ -282,6 +488,7 @@ Assistant:
 - Ask the user for clarification if instructions are ambiguous or if you need help.
 - NEVER run risky or harmful code without explicit user consent.
 - ALWAYS execute code cells right after inserting or modifying them to ensure they work as intended.
+- NEVER write a code cell and leave it unexecuted.
 """
 
 # Create backend with workspace configuration
@@ -297,7 +504,7 @@ agent = create_deep_agent(
     system_prompt=system_prompt,
     backend=backend,
     checkpointer=MemorySaver(),
-    tools=[create_notebook, insert_code_cell, modify_cell, execute_cell],
+    tools=[get_notebook_state, create_notebook, insert_code_cell, modify_cell, execute_cell],
 )
 
 # Log configuration if in debug mode


### PR DESCRIPTION
- Implement `start_notebook_kernel` to manage Jupyter kernel sessions.
- Enhance `get_notebook_kernel_id` with detailed error handling.
- Introduce `get_notebook_state` to summarize notebook cell information.
- Update `execute_cell` to automatically start a kernel if needed.
- Include `get_notebook_state` in agent tools for improved functionality.
- Update README