### PR TITLE
Adopt shared HostConfig + deepagents.toml support (LabConfig)

### DIFF
--- a/deepagent_lab/config.py
+++ b/deepagent_lab/config.py
@@ -1,106 +1,93 @@
-"""
-Configuration management for deepagent-lab.
+"""Configuration management for deepagent-lab.
 
-This module provides a centralized configuration system with environment variable
-support. All environment variables use the DEEPAGENT_ prefix for consistency
-with deepagent-dash, allowing agents to be shared between the two libraries.
-
-Usage:
-    from deepagent_lab.config import get_config, WORKSPACE_ROOT, JUPYTER_TOKEN
-
-    # Use predefined constants
-    workspace = WORKSPACE_ROOT
-    token = JUPYTER_TOKEN
-
-    # Or get custom configuration
-    custom_value = get_config("custom_key", default="default_value")
+Shares the ``DEEPAGENT_*`` schema + TOML loader with the deep-agent family via
+``langgraph_stream_parser.host``. ``LabConfig`` is the full resolved config
+(``defaults < deepagents.toml < DEEPAGENT_* env < overrides``) used by the
+launcher and `--show-config`. The module-level constants below are an
+env+defaults view (no TOML) kept for back-compat with existing call sites
+(``agent.py``, ``agent_wrapper.py``).
 """
 import os
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Callable, Any
+from typing import Any, Callable, ClassVar, Optional
+
+from langgraph_stream_parser.host import HostConfig, load_toml_config  # noqa: F401  (re-exported for callers)
 
 
 def get_config(key: str, default: Any = None, type_cast: Optional[Callable] = None) -> Any:
-    """
-    Get configuration value with environment variable override.
+    """Get a config value from a ``DEEPAGENT_{KEY}`` env var (env-only helper).
 
-    Priority:
-    1. Environment variable DEEPAGENT_{KEY}
-    2. Default value
-
-    Args:
-        key: Configuration key (will be uppercased for env var)
-        default: Default value if env var not set
-        type_cast: Optional function to cast env var value
-
-    Returns:
-        Configuration value with appropriate type
-
-    Examples:
-        >>> # String configuration
-        >>> get_config("agent_module", default="deepagent_lab.agent")
-        'deepagent_lab.agent'
-
-        >>> # Integer configuration
-        >>> get_config("port", default=8888, type_cast=int)
-        8888
-
-        >>> # Boolean configuration
-        >>> get_config("debug", default=False,
-        ...            type_cast=lambda x: str(x).lower() in ("true", "1", "yes"))
-        False
-
-        >>> # With environment variable set
-        >>> os.environ['DEEPAGENT_PORT'] = '9999'
-        >>> get_config("port", default=8888, type_cast=int)
-        9999
+    Priority: env var ``DEEPAGENT_{KEY}`` > default. Retained for ad-hoc keys
+    (e.g. ``execute_timeout``) and back-compat.
     """
     env_key = f"DEEPAGENT_{key.upper()}"
     env_value = os.getenv(env_key)
-
     if env_value is not None:
         return type_cast(env_value) if type_cast else env_value
     return default
 
 
-# === Workspace Configuration ===
+def _to_bool(value: str) -> bool:
+    return str(value).strip().lower() in ("true", "1", "yes", "on")
 
-_workspace_path = get_config("workspace_root", default=None)
-WORKSPACE_ROOT: Optional[Path] = Path(_workspace_path).resolve() if _workspace_path else None
 
-# === Agent Configuration ===
+@dataclass
+class LabConfig(HostConfig):
+    """deepagent-lab's view of the shared config.
 
-# Combined agent spec in format "module_or_file:variable"
-# This takes precedence over separate AGENT_MODULE and AGENT_VARIABLE
-# Compatible with deepagent-dash
-AGENT_SPEC = get_config("agent_spec", default=None)
+    Adds the Jupyter / model / agent-loading keys on top of ``HostConfig``,
+    resolved through the same ``defaults < deepagents.toml < DEEPAGENT_* env <
+    overrides`` chain. (``DEEPAGENT_AGENT_SPEC`` is already canonical here.)
+    """
 
-# Separate module and variable configuration (used if AGENT_SPEC not set)
-AGENT_MODULE = get_config("agent_module", default="deepagent_lab.agent")
-AGENT_VARIABLE = get_config("agent_variable", default=None)
+    agent_module: str = "deepagent_lab.agent"
+    agent_variable: Optional[str] = None
+    jupyter_token: str = "12345"
+    jupyter_server_url: str = "http://localhost:8889"
+    model_name: str = "anthropic:claude-sonnet-4-6"
+    model_temperature: float = 0.0
+    virtual_mode: bool = True
+    execute_timeout: float = 300.0
 
-# === Jupyter Server Configuration ===
+    _ENV: ClassVar[dict] = {
+        "agent_module": ("DEEPAGENT_AGENT_MODULE", str),
+        "agent_variable": ("DEEPAGENT_AGENT_VARIABLE", str),
+        "jupyter_token": ("DEEPAGENT_JUPYTER_TOKEN", str),
+        "jupyter_server_url": ("DEEPAGENT_JUPYTER_SERVER_URL", str),
+        "model_name": ("DEEPAGENT_MODEL_NAME", str),
+        "model_temperature": ("DEEPAGENT_MODEL_TEMPERATURE", float),
+        "virtual_mode": ("DEEPAGENT_VIRTUAL_MODE", _to_bool),
+        "execute_timeout": ("DEEPAGENT_EXECUTE_TIMEOUT", float),
+    }
+    _TOML: ClassVar[dict] = {
+        "agent_module": "agent.module",
+        "agent_variable": "agent.variable",
+        "jupyter_token": "jupyter.token",
+        "jupyter_server_url": "jupyter.server_url",
+        "model_name": "model.name",
+        "model_temperature": "model.temperature",
+        "virtual_mode": "jupyter.virtual_mode",
+        "execute_timeout": "jupyter.execute_timeout",
+    }
 
-JUPYTER_TOKEN = get_config("jupyter_token", default="12345")
-JUPYTER_SERVER_URL = get_config("jupyter_server_url", default="http://localhost:8889")
 
-# === Model Configuration ===
+# Module-level constants — an env + defaults view (no TOML) derived from
+# LabConfig, for back-compat with call sites that read ``config.X``. Full
+# TOML-aware resolution is ``LabConfig.resolve()`` (used by the launcher).
+_cfg = LabConfig.resolve(use_toml=False)
 
-MODEL_NAME = get_config("model_name", default="anthropic:claude-sonnet-4-6")
-MODEL_TEMPERATURE = get_config("model_temperature", default=0.0, type_cast=float)
-
-# === Debug Configuration ===
-
-DEBUG = get_config(
-    "debug",
-    default=False,
-    type_cast=lambda x: str(x).lower() in ("true", "1", "yes")
+WORKSPACE_ROOT: Optional[Path] = (
+    _cfg.workspace_root.resolve()
+    if _cfg.sources.get("workspace_root") != "default"
+    else None
 )
-
-# === Backend Configuration ===
-
-VIRTUAL_MODE = get_config(
-    "virtual_mode",
-    default=True,
-    type_cast=lambda x: str(x).lower() in ("true", "1", "yes")
-)
+AGENT_SPEC = _cfg.agent_spec
+AGENT_MODULE = _cfg.agent_module
+AGENT_VARIABLE = _cfg.agent_variable
+JUPYTER_TOKEN = _cfg.jupyter_token
+JUPYTER_SERVER_URL = _cfg.jupyter_server_url
+MODEL_NAME = _cfg.model_name
+MODEL_TEMPERATURE = _cfg.model_temperature
+DEBUG = _cfg.debug
+VIRTUAL_MODE = _cfg.virtual_mode

--- a/deepagent_lab/launcher.py
+++ b/deepagent_lab/launcher.py
@@ -41,6 +41,13 @@ def main():
     # Parse command line arguments
     args = sys.argv[1:]
 
+    # --show-config: print the resolved config (value, source, env var / TOML
+    # key for each) and exit — no need to remember the DEEPAGENT_* names.
+    if "--show-config" in args:
+        from deepagent_lab.config import LabConfig
+        print(LabConfig.resolve().describe())
+        return
+
     # Check if user specified a port
     user_port = None
     port_specified = False

--- a/tests/test_labconfig.py
+++ b/tests/test_labconfig.py
@@ -1,0 +1,78 @@
+"""Tests for LabConfig — deepagent-lab's HostConfig subclass (TOML-aware)."""
+from pathlib import Path
+
+import pytest
+
+from deepagent_lab.config import LabConfig
+
+
+@pytest.fixture
+def isolated(tmp_path, monkeypatch):
+    """Point the global deepagents config at an empty dir so the host machine's
+    ~/.deepagents/config.toml can't leak in."""
+    empty = tmp_path / "global"
+    empty.mkdir()
+    monkeypatch.setenv("DEEPAGENTS_CONFIG_HOME", str(empty))
+    return tmp_path
+
+
+def _toml(d: Path, body: str) -> None:
+    (d / "deepagents.toml").write_text(body)
+
+
+def test_defaults(isolated, tmp_path):
+    cfg = LabConfig.resolve(env={}, toml_start=tmp_path)
+    assert cfg.model_name == "anthropic:claude-sonnet-4-6"
+    assert cfg.model_temperature == 0.0
+    assert cfg.jupyter_token == "12345"
+    assert cfg.jupyter_server_url == "http://localhost:8889"
+    assert cfg.virtual_mode is True
+    assert cfg.agent_module == "deepagent_lab.agent"
+    assert cfg.agent_variable is None
+    assert cfg.execute_timeout == 300.0
+
+
+def test_env_layer(isolated, tmp_path):
+    cfg = LabConfig.resolve(
+        env={
+            "DEEPAGENT_MODEL_NAME": "openai:gpt-4",
+            "DEEPAGENT_MODEL_TEMPERATURE": "0.7",
+            "DEEPAGENT_VIRTUAL_MODE": "false",
+            "DEEPAGENT_AGENT_SPEC": "x.py:g",
+        },
+        toml_start=tmp_path,
+    )
+    assert cfg.model_name == "openai:gpt-4"
+    assert cfg.model_temperature == 0.7
+    assert cfg.virtual_mode is False
+    assert cfg.agent_spec == "x.py:g"
+
+
+def test_toml_layer(isolated, tmp_path):
+    _toml(tmp_path,
+          '[model]\nname = "anthropic:claude-3"\ntemperature = 0.3\n'
+          '[jupyter]\ntoken = "tok"\nvirtual_mode = false\nexecute_timeout = 60.0\n'
+          '[agent]\nspec = "a.py:g"\nmodule = "custom.mod"\n')
+    cfg = LabConfig.resolve(env={}, toml_start=tmp_path)
+    assert cfg.model_name == "anthropic:claude-3"
+    assert cfg.model_temperature == 0.3
+    assert cfg.jupyter_token == "tok"
+    assert cfg.virtual_mode is False
+    assert cfg.execute_timeout == 60.0
+    assert cfg.agent_spec == "a.py:g"
+    assert cfg.agent_module == "custom.mod"
+
+
+def test_env_beats_toml(isolated, tmp_path):
+    _toml(tmp_path, '[model]\nname = "from-toml"\n')
+    cfg = LabConfig.resolve(env={"DEEPAGENT_MODEL_NAME": "from-env"}, toml_start=tmp_path)
+    assert cfg.model_name == "from-env"
+    assert cfg.sources["model_name"] == "env:DEEPAGENT_MODEL_NAME"
+
+
+def test_describe_lists_var_names(isolated, tmp_path):
+    text = LabConfig.resolve(env={}, toml_start=tmp_path).describe()
+    assert "DEEPAGENT_MODEL_NAME" in text
+    assert "DEEPAGENT_JUPYTER_TOKEN" in text
+    assert "jupyter.token" in text
+    assert "DEEPAGENT_AGENT_SPEC" in text


### PR DESCRIPTION
Adopts the unified config layer (langgraph-stream-parser#11), following the deepagent-code template.

> Stacked on #7 (`fix/critical-default-agent-bugs`). Merge order: parser #10 → #11 → release → this repo #7 → this PR.

## Changes
- **`LabConfig(HostConfig)`** adds the Jupyter / model / agent-loading keys (`model_name`, `model_temperature`, `jupyter_token`, `jupyter_server_url`, `virtual_mode`, `execute_timeout`, `agent_module`, `agent_variable`) and resolves through the shared chain: `defaults < deepagents.toml < DEEPAGENT_* env < overrides`. **Lab gains `deepagents.toml` support** (it was env-only before).
- The module-level constants (`WORKSPACE_ROOT`, `MODEL_NAME`, …) are now an env+defaults view derived from `LabConfig.resolve(use_toml=False)` — identical behavior, so the existing `test_config.py` passes unchanged. `get_config` retained.
- **`deepagent-lab --show-config`** prints each value, its source, and the env var + TOML key.
- Lab was already on the canonical `DEEPAGENT_AGENT_SPEC` — no name reconcile needed.

## Tests
56 pass (51 existing + 5 new `test_labconfig`).