### PR TITLE
Launcher -a/--agent + keyless --demo; family README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ A JupyterLab extension to allow **your** LangChain agents access to JuputerLab n
 
 Watch the full demo video here: [https://www.youtube.com/watch?v=vGA2vzMSQzo](https://www.youtube.com/watch?v=vGA2vzMSQzo)
 
+## One agent, every surface
+
+deepagent-lab is the JupyterLab surface of the **deep-agent family**: write your agent once — any LangGraph `CompiledGraph` — and run it on every surface with the same spec string (`module:attr` or `path/to/file.py:attr`), the same `deepagents.toml` config file, and the same `DEEPAGENT_*` environment variables.
+
+| Surface | Package | Try it |
+|---|---|---|
+| Web app | [cowork-dash](https://github.com/dkedar7/cowork-dash) | `cowork-dash run --agent my_agent.py:graph` |
+| JupyterLab | deepagent-lab | **you are here** |
+| Terminal | [deepagent-code](https://github.com/dkedar7/deepagent-code) | `deepagent-code -a my_agent.py:graph` |
+| VS Code | [deepagent-vscode](https://github.com/dkedar7/deepagent-vscode) | chat participant + stdio sidecar |
+| Reference agent | [deepagent-hermes](https://github.com/dkedar7/deepagent-hermes) | `DEEPAGENT_AGENT_SPEC=deepagent_hermes.agent:graph` on any surface |
+| Shared core | [langgraph-stream-parser](https://github.com/dkedar7/langgraph-stream-parser) | typed events + config resolver behind every surface |
+
 ## Features
 
 - **Chat Interface**: Sidebar for natural conversations with your agent
@@ -63,6 +76,17 @@ That's it! The launcher will:
 # All jupyter lab arguments are supported
 deepagent-lab --no-browser
 deepagent-lab --port 8889
+
+# Pick the agent right from the launcher (same spec format as every
+# deep-agent surface; sets DEEPAGENT_AGENT_SPEC for you)
+deepagent-lab -a my_agent.py:graph
+
+# No agent or API key yet? Launch with the keyless demo agent
+deepagent-lab --demo
+
+# Print the resolved configuration (each value, its source, and the
+# env var / deepagents.toml key that sets it) and exit
+deepagent-lab --show-config
 ```
 
 ### Alternative: Manual Configuration

--- a/deepagent_lab/launcher.py
+++ b/deepagent_lab/launcher.py
@@ -6,17 +6,54 @@ This script wraps the 'jupyter lab' command to automatically configure
 the Jupyter server settings and make them available to agents.
 
 Usage:
-    deepagent-lab [jupyter lab args...]
+    deepagent-lab [options] [jupyter lab args...]
 
 Example:
     deepagent-lab --port 8889
     deepagent-lab --no-browser
+    deepagent-lab -a my_agent.py:graph     # pick the agent, same spec format
+                                           # as every deep-agent surface
+    deepagent-lab --demo                   # keyless demo agent, no API key
+    deepagent-lab --show-config            # print resolved config and exit
 """
 import os
 import sys
 import socket
 import secrets
 import subprocess
+
+# The keyless echo agent shipped with the shared core — see `--demo`.
+DEMO_AGENT_SPEC = "langgraph_stream_parser.demo.stub:graph"
+
+
+def extract_agent_args(args):
+    """Split our agent flags out of the passthrough jupyter-lab args.
+
+    Handles ``-a SPEC`` / ``--agent SPEC`` / ``--agent=SPEC`` and ``--demo``.
+    Returns ``(agent_spec, demo, remaining_args)`` — remaining_args go to
+    ``jupyter lab`` untouched.
+    """
+    agent_spec = None
+    demo = False
+    remaining = []
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ("-a", "--agent") and i + 1 < len(args):
+            agent_spec = args[i + 1]
+            i += 2
+            continue
+        if arg.startswith("--agent="):
+            agent_spec = arg.split("=", 1)[1]
+            i += 1
+            continue
+        if arg == "--demo":
+            demo = True
+            i += 1
+            continue
+        remaining.append(arg)
+        i += 1
+    return agent_spec, demo, remaining
 
 
 def find_available_port(start_port=8888, max_attempts=10):
@@ -47,6 +84,19 @@ def main():
         from deepagent_lab.config import LabConfig
         print(LabConfig.resolve().describe())
         return
+
+    # Our agent flags must not reach `jupyter lab` (it would reject them).
+    agent_spec, demo, args = extract_agent_args(args)
+    if demo and agent_spec:
+        print("ERROR: --demo and -a/--agent are mutually exclusive")
+        sys.exit(1)
+    if demo:
+        agent_spec = DEMO_AGENT_SPEC
+    if agent_spec:
+        # The sidebar extension reads DEEPAGENT_AGENT_SPEC (env beats the
+        # built-in default; deepagents.toml still works when nothing is set).
+        os.environ["DEEPAGENT_AGENT_SPEC"] = agent_spec
+        print(f"Agent spec: {agent_spec}")
 
     # Check if user specified a port
     user_port = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     "jupyter_server>=2.0.1,<3",
     "langgraph>=0.0.1",
-    "langgraph-stream-parser>=0.2,<0.3",
+    "langgraph-stream-parser>=0.2.2,<0.3",
     "python-dotenv>=0.19.0",
     "deepagents>=0.1.0",
 ]

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -4,7 +4,73 @@ Tests for launcher utilities (launcher.py).
 import socket
 import pytest
 from unittest.mock import Mock, patch, MagicMock
-from deepagent_lab.launcher import find_available_port, generate_token
+from deepagent_lab.launcher import (
+    DEMO_AGENT_SPEC,
+    extract_agent_args,
+    find_available_port,
+    generate_token,
+    main,
+)
+
+
+class TestExtractAgentArgs:
+    """Tests for the -a/--agent/--demo flag extraction."""
+
+    def test_no_agent_flags_pass_through(self):
+        spec, demo, rest = extract_agent_args(["--port", "9000", "--no-browser"])
+        assert spec is None
+        assert demo is False
+        assert rest == ["--port", "9000", "--no-browser"]
+
+    def test_short_flag(self):
+        spec, demo, rest = extract_agent_args(["-a", "my.py:graph", "--no-browser"])
+        assert spec == "my.py:graph"
+        assert rest == ["--no-browser"]
+
+    def test_long_flag_with_equals(self):
+        spec, _, rest = extract_agent_args(["--agent=pkg.mod:g"])
+        assert spec == "pkg.mod:g"
+        assert rest == []
+
+    def test_demo_flag(self):
+        spec, demo, rest = extract_agent_args(["--demo", "--port", "9000"])
+        assert spec is None
+        assert demo is True
+        assert rest == ["--port", "9000"]
+
+
+class TestMainAgentWiring:
+    """main() wires the agent flags into DEEPAGENT_AGENT_SPEC."""
+
+    def _run_main(self, argv, monkeypatch):
+        calls = {}
+
+        def fake_run(cmd, env=None):
+            calls["cmd"] = cmd
+            calls["env_spec"] = (env or {}).get("DEEPAGENT_AGENT_SPEC")
+
+        monkeypatch.setattr("deepagent_lab.launcher.subprocess.run", fake_run)
+        monkeypatch.setattr("sys.argv", ["deepagent-lab"] + argv)
+        monkeypatch.delenv("DEEPAGENT_AGENT_SPEC", raising=False)
+        main()
+        return calls
+
+    def test_demo_sets_stub_spec(self, monkeypatch):
+        calls = self._run_main(["--demo", "--no-browser"], monkeypatch)
+        assert calls["env_spec"] == DEMO_AGENT_SPEC
+        # the flag itself never reaches jupyter lab
+        assert "--demo" not in calls["cmd"]
+
+    def test_agent_flag_sets_spec(self, monkeypatch):
+        calls = self._run_main(["-a", "my.py:graph", "--no-browser"], monkeypatch)
+        assert calls["env_spec"] == "my.py:graph"
+        assert "-a" not in calls["cmd"]
+        assert "my.py:graph" not in calls["cmd"]
+
+    def test_demo_and_agent_conflict(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["deepagent-lab", "--demo", "-a", "x.py:g"])
+        with pytest.raises(SystemExit):
+            main()
 
 
 class TestFindAvailablePort:


### PR DESCRIPTION
## What

- **`deepagent-lab -a/--agent <spec>`** — pick the agent straight from the launcher (`-a x`, `--agent x`, `--agent=x` all work). The launcher extracts the flag before passing the remaining args to `jupyter lab` and exports `DEEPAGENT_AGENT_SPEC` for the sidebar extension.
- **`deepagent-lab --demo`** — launches with the shared keyless echo stub (`langgraph_stream_parser.demo.stub:graph`): the whole extension (sidebar, streaming, HITL plumbing) runs with no API key.
- README: *One agent, every surface* family table + flag docs (`--show-config` already existed).
- Parser pinned `>=0.2.2,<0.3` (the release that ships the stub).

## Why

P0 usability batch: lab was the only surface where choosing an agent required knowing the env var. Now the launcher matches `deepagent-code -a` / `cowork-dash run -a`.

## Tests

7 new launcher tests (flag extraction forms, demo→stub env wiring with jupyter args untouched, demo/agent conflict). Suite: 63 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)