### PR TITLE
Adopt AG-UI: widen parser ceiling + [agui] extra (v0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-06-14
+
+### Added
+
+- Adopt AG-UI: widen the langgraph-stream-parser ceiling to `<0.5` and add an `[agui]` extra so this surface's agent can be served over AG-UI via `langstage-agui`. Additive; no runtime changes.
+
 ## [0.4.0] - 2026-06-12
 
 **deepagent-lab is now `langstage-jupyter`** — the JupyterLab stage of the LangStage family ("every stage for your LangGraph agent").

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ langstage-jupyter is the JupyterLab stage of the **LangStage family**: write you
 | Reference agent | [langstage-hermes](https://github.com/dkedar7/langstage-hermes) | `LANGSTAGE_AGENT_SPEC=langstage_hermes.agent:graph` on any stage |
 | Shared core | [langgraph-stream-parser](https://github.com/dkedar7/langgraph-stream-parser) | typed events + config resolver behind every stage |
 
+### Serve over AG-UI
+
+This surface's agent — any LangGraph `CompiledGraph` — can also be served over the [AG-UI protocol](https://github.com/dkedar7/langgraph-stream-parser). Install the extra and point it at your agent spec:
+
+```bash
+pip install "langgraph-stream-parser[agui]"
+langstage-agui --agent my_agent.py:graph
+```
+
 📖 **Full documentation:** <https://dkedar7.github.io/langstage-docs/>
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     "jupyter_server>=2.0.1,<3",
     "langgraph>=0.0.1",
-    "langgraph-stream-parser>=0.3,<0.4",
+    "langgraph-stream-parser>=0.3,<0.5",
     "python-dotenv>=0.19.0",
     "deepagents>=0.1.0",
 ]
@@ -42,6 +42,7 @@ dev = [
     "pytest-cov>=4.0.0",
     "pytest-asyncio>=0.21.0",
 ]
+agui = ["langgraph-stream-parser[agui]>=0.4,<0.5"]
 
 [tool.hatch.version]
 source = "nodejs"


### PR DESCRIPTION
Additive AG-UI adoption for the JupyterLab LangStage surface. Widens the langgraph-stream-parser ceiling to <0.5 and adds an [agui] optional-dependency extra so this surface's agent (any LangGraph CompiledGraph) can be served over the AG-UI protocol via langstage-agui. No runtime behavior, frontend, or TS/React changes; docs + CHANGELOG updated and version bumped to 0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)