### PR TITLE
Fix stale Python classifiers (3.11-3.14)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "jupyter_server>=2.0.1,<3",


### PR DESCRIPTION
The classifiers claimed 3.8-3.10, which requires-python (>=3.11) forbids. Corrected to 3.11-3.14; CI already tests 3.14.