### PR TITLE
fix: declare 5 undeclared runtime deps + minimal-install guard (0.5.1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,3 +65,23 @@ jobs:
         files: ./coverage.xml
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  # Guard against undeclared runtime dependencies: install the Python package
+  # with NO extras (declared deps only, like a real `pip install langstage-jupyter`)
+  # and smoke-import every module. A top-level import that is only available
+  # transitively will fail here.
+  minimal-install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install with NO extras (declared deps only)
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Import smoke on a minimal install
+        run: |
+          python -c "import langstage_jupyter; print('ok')"
+          python -c "import langstage_jupyter.config, langstage_jupyter.agent_wrapper, langstage_jupyter.handlers, langstage_jupyter.agent, langstage_jupyter.launcher; print('ok')"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,8 +68,11 @@ jobs:
 
   # Guard against undeclared runtime dependencies: install the Python package
   # with NO extras (declared deps only, like a real `pip install langstage-jupyter`)
-  # and smoke-import every module. A top-level import that is only available
-  # transitively will fail here.
+  # and smoke-import every module. A top-level import only available transitively
+  # fails here. For this JupyterLab extension we first build the prebuilt
+  # labextension (so the pip build hook's skip-if-exists skips the npm build at
+  # install time), then install into an ISOLATED venv so the jupyterlab/Node
+  # deps pulled in to run the build don't mask a missing declaration.
   minimal-install:
     runs-on: ubuntu-latest
     steps:
@@ -77,11 +80,18 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Install with NO extras (declared deps only)
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Build the prebuilt labextension (lets the pip build hook skip npm)
         run: |
-          python -m pip install --upgrade pip
-          pip install .
-      - name: Import smoke on a minimal install
+          python -m pip install --upgrade pip "jupyterlab>=4.0,<5"
+          jlpm install --no-immutable
+          jlpm build:prod
+      - name: Clean-install with NO extras (declared deps only) + import smoke
         run: |
-          python -c "import langstage_jupyter; print('ok')"
-          python -c "import langstage_jupyter.config, langstage_jupyter.agent_wrapper, langstage_jupyter.handlers, langstage_jupyter.agent, langstage_jupyter.launcher; print('ok')"
+          python -m venv /tmp/mi
+          /tmp/mi/bin/pip install --upgrade pip
+          /tmp/mi/bin/pip install .
+          /tmp/mi/bin/python -c "import langstage_jupyter; print('ok')"
+          /tmp/mi/bin/python -c "import langstage_jupyter.config, langstage_jupyter.agent_wrapper, langstage_jupyter.handlers, langstage_jupyter.agent, langstage_jupyter.launcher; print('ok')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.1 - 2026-06-16
+
+### Fixed
+- Declare previously-undeclared runtime dependencies that `langstage_jupyter/agent.py`
+  imports at module top level — `langchain`, `requests`, `nbformat`, `jupyter_client`,
+  `tornado`. They were only present transitively (langchain via deepagents, etc.), so a
+  fresh `pip install langstage-jupyter` could `ModuleNotFoundError` on those paths. Found
+  by rolling the family's minimal-install CI guard.
+
+### CI
+- Added a `minimal-install` job (install with no extras + deep import smoke incl. agent.py).
+
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,15 @@ dependencies = [
     "langgraph-stream-parser>=0.3,<0.5",
     "python-dotenv>=0.19.0",
     "deepagents>=0.1.0",
+    # Direct top-level imports in langstage_jupyter/agent.py. Previously only
+    # available transitively (langchain via deepagents; requests via langsmith;
+    # nbformat/jupyter_client/tornado via jupyter_server) — declared explicitly
+    # so a minimal `pip install` cannot break on a transitive drop.
+    "langchain>=1.0",
+    "nbformat>=5.0",
+    "requests>=2.25",
+    "jupyter_client>=7.0",
+    "tornado>=6.1",
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 


### PR DESCRIPTION
`langstage_jupyter/agent.py` imports `langchain`, `requests`, `nbformat`, `jupyter_client`, `tornado` at module top level, but none were declared — they came transitively (langchain via deepagents, etc.). Fresh `pip install langstage-jupyter` could break on those paths. Now declared with family-consistent floors. Plus the family `minimal-install` CI guard. Found by rolling the langstage 0.11.1 guard across the family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)