### PR TITLE
fix: jupyterlab runtime dep + provider-safe default agent name (0.5.3)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,10 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install pytest pytest-cov pytest-asyncio
         pip install jupyter_server>=2.0.1 langgraph>=0.0.1 python-dotenv>=0.19.0 deepagents>=0.1.0
-        pip install "langgraph-stream-parser>=0.6,<0.7"
+        # JupyterLab is now a declared runtime dep (gh #24); install it so the
+        # launcher guard test exercises the real "present" path.
+        pip install "jupyterlab>=4.0,<5"
+        pip install "langgraph-stream-parser>=0.6.3,<0.7"
         pip install nbformat requests tornado traitlets jupyter_client
 
     - name: Add package to Python path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.5.3 - 2026-06-18
+
+### Fixed
+- **First-run launcher failure on a clean install (gh #24).** `jupyterlab` was pinned
+  only in `[build-system].requires`, so `pip install langstage-jupyter` left the user
+  without a Lab UI and the headline `langstage-jupyter` launcher died on
+  `Jupyter command 'jupyter-lab' not found`. Declared `jupyterlab>=4.0.0,<5` as a runtime
+  dependency. The launcher's old `except FileNotFoundError` guard never fired (the
+  `jupyter` dispatcher *is* present), so it now pre-checks
+  `importlib.util.find_spec("jupyterlab")` and prints an actionable `pip install jupyterlab`
+  hint before launching.
+- **Default agent name 400'd OpenAI-compatible providers (gh #23).** The shipped default
+  `name="Default Agent"` flows into the LLM message `name` field, which OpenAI-compatible
+  providers (e.g. via OpenRouter) require to match `^[^\s<|\\/>]+$` — no spaces — so the
+  default agent hard-`400`'d on the second turn. Renamed the default to `default-agent`
+  and bumped the core pin to `langgraph-stream-parser>=0.6.3`, which slugifies any unsafe
+  display name as an upstream backstop for custom agents.
+
+### CI
+- The `test` job now installs `jupyterlab` (declared runtime dep) and pins
+  `langgraph-stream-parser>=0.6.3` to match pyproject.
+
+
 ## 0.5.2 - 2026-06-16
 
 ### Changed

--- a/langstage_jupyter/agent.py
+++ b/langstage_jupyter/agent.py
@@ -520,7 +520,7 @@ chat_model = init_chat_model(MODEL_NAME, temperature=MODEL_TEMPERATURE)
 agent = _build_default_agent(
     workspace=str(WORKSPACE),
     model=chat_model,
-    name="Default Agent",
+    name="default-agent",
     system_prompt=system_prompt,
     tools=[get_notebook_state, create_notebook, insert_code_cell, modify_cell, execute_cell],
     virtual_mode=config.VIRTUAL_MODE,

--- a/langstage_jupyter/launcher.py
+++ b/langstage_jupyter/launcher.py
@@ -16,6 +16,7 @@ Example:
     langstage-jupyter --demo                   # keyless demo agent, no API key
     langstage-jupyter --show-config            # print resolved config and exit
 """
+import importlib.util
 import os
 import sys
 import socket
@@ -24,6 +25,29 @@ import subprocess
 
 # The keyless echo agent shipped with the shared core — see `--demo`.
 DEMO_AGENT_SPEC = "langgraph_stream_parser.demo.stub:graph"
+
+
+def ensure_jupyterlab():
+    """Fail fast with an actionable hint if JupyterLab isn't importable.
+
+    JupyterLab is a declared runtime dependency, but a user on an older/odd
+    install may still lack it. The launcher runs ``jupyter lab``; if JupyterLab
+    is absent the ``jupyter`` dispatcher (shipped by ``jupyter_server``) is
+    *present* and simply prints its help + ``jupyter-lab not found`` and exits
+    non-zero — it does **not** raise ``FileNotFoundError``. So the old
+    ``except FileNotFoundError`` guard never fired and the user got a cryptic
+    help dump instead of guidance (gh #24). Pre-checking the import is the
+    reliable signal.
+    """
+    if importlib.util.find_spec("jupyterlab") is None:
+        print(
+            "ERROR: JupyterLab is not installed, so `jupyter lab` cannot start.\n"
+            "  Install it with:\n"
+            "    pip install jupyterlab\n"
+            "  (or reinstall this package, which now depends on it: "
+            "pip install --upgrade langstage-jupyter)"
+        )
+        sys.exit(1)
 
 
 def extract_agent_args(args):
@@ -84,6 +108,11 @@ def main():
         from langstage_jupyter.config import LabConfig
         print(LabConfig.resolve().describe())
         return
+
+    # Headline command runs `jupyter lab` — bail with a clear hint up front if
+    # JupyterLab isn't installed, instead of letting the jupyter dispatcher dump
+    # its help later (gh #24).
+    ensure_jupyterlab()
 
     # Our agent flags must not reach `jupyter lab` (it would reject them).
     agent_spec, demo, args = extract_agent_args(args)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,17 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
+    # The package IS a prebuilt JupyterLab extension and the headline launcher
+    # runs `jupyter lab`, so JupyterLab is a hard runtime requirement — not just
+    # a build dep. It was pinned only in [build-system].requires, so a clean
+    # `pip install langstage-jupyter` left the user with no Lab UI and the
+    # launcher dying on `jupyter-lab not found` (gh #24).
+    "jupyterlab>=4.0.0,<5",
     "jupyter_server>=2.0.1,<3",
     "langgraph>=0.0.1",
-    "langgraph-stream-parser>=0.6,<0.7",
+    # >=0.6.3 carries the agent-name slugify fix that keeps OpenAI-compatible
+    # providers from 400ing on a display name with a space (gh #23).
+    "langgraph-stream-parser>=0.6.3,<0.7",
     "python-dotenv>=0.19.0",
     "deepagents>=0.1.0",
     # Direct top-level imports in langstage_jupyter/agent.py. Previously only
@@ -51,7 +59,7 @@ dev = [
     "pytest-cov>=4.0.0",
     "pytest-asyncio>=0.21.0",
 ]
-agui = ["langgraph-stream-parser[agui]>=0.6,<0.7"]
+agui = ["langgraph-stream-parser[agui]>=0.6.3,<0.7"]
 
 [tool.hatch.version]
 source = "nodejs"

--- a/tests/test_bug_regressions.py
+++ b/tests/test_bug_regressions.py
@@ -1,0 +1,84 @@
+"""Regressions for the daily-routine bugs #23 and #24.
+
+#23 — the shipped default agent name had a space ("Default Agent"), which leaks
+into the LLM message `name` field and 400s on OpenAI-compatible providers on the
+second turn. The default must be provider-safe; the upstream factory also
+slugifies as a backstop (langgraph-stream-parser>=0.6.3).
+
+#24 — `pip install langstage-jupyter` didn't pull in JupyterLab (it was only a
+build dep), so the headline launcher (`jupyter lab`) failed on a fresh install,
+and the launcher's "install jupyterlab" guard never fired (jupyter IS present;
+only the jupyter-lab subcommand is missing). JupyterLab is now a runtime dep and
+the launcher pre-checks the import.
+"""
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+# tomllib is stdlib on 3.11+ (this package requires >=3.11).
+import tomllib
+
+_REPO = Path(__file__).resolve().parent.parent
+_AGENT_SRC = (_REPO / "langstage_jupyter" / "agent.py").read_text(encoding="utf-8")
+_PYPROJECT = tomllib.loads((_REPO / "pyproject.toml").read_text(encoding="utf-8"))
+
+
+def _shipped_default_agent_name() -> str:
+    """The literal `name="..."` passed to the default-agent factory call."""
+    start = _AGENT_SRC.index("_build_default_agent(")
+    m = re.search(r"""\bname\s*=\s*["']([^"']*)["']""", _AGENT_SRC[start:])
+    assert m, "no name= literal in the _build_default_agent(...) call"
+    return m.group(1)
+
+
+def test_default_agent_name_is_provider_safe():
+    """#23: shipped default name must not contain spaces or <|\\/> (OpenAI 400)."""
+    from langgraph_stream_parser.demo.agent import _safe_agent_name
+
+    name = _shipped_default_agent_name()
+    assert " " not in name, f"default agent name {name!r} contains a space"
+    # The slugifier is a no-op on an already-safe name.
+    assert _safe_agent_name(name) == name
+
+
+def test_core_floor_carries_slugify_fix():
+    """#23: the core dep floor must be >=0.6.3 (where the slugify fix landed)."""
+    deps = _PYPROJECT["project"]["dependencies"]
+    core = next(d for d in deps if d.lower().startswith("langgraph-stream-parser"))
+    assert ">=0.6.3" in core, core
+
+
+def test_jupyterlab_is_a_declared_runtime_dependency():
+    """#24: JupyterLab must be a runtime dep, not build-only."""
+    deps = _PYPROJECT["project"]["dependencies"]
+    assert any(d.lower().startswith("jupyterlab") for d in deps), deps
+
+
+class TestEnsureJupyterlabGuard:
+    """#24: the launcher must fail fast with an actionable hint, not a help dump."""
+
+    def test_exits_with_hint_when_jupyterlab_missing(self, monkeypatch, capsys):
+        from langstage_jupyter import launcher
+
+        real_find_spec = importlib.util.find_spec
+
+        def fake_find_spec(name, *args, **kwargs):
+            if name == "jupyterlab":
+                return None  # simulate JupyterLab not installed
+            return real_find_spec(name, *args, **kwargs)
+
+        monkeypatch.setattr(launcher.importlib.util, "find_spec", fake_find_spec)
+
+        with pytest.raises(SystemExit) as exc:
+            launcher.ensure_jupyterlab()
+        assert exc.value.code == 1
+        assert "pip install jupyterlab" in capsys.readouterr().out
+
+    def test_passes_when_jupyterlab_present(self):
+        from langstage_jupyter import launcher
+
+        # JupyterLab is a declared runtime dep, so it must import cleanly here.
+        launcher.ensure_jupyterlab()  # must not raise


### PR DESCRIPTION
Resolves the two bugs the daily power-user dogfooding routine filed for langstage-jupyter (Thu, 2026-06-18).

## #24 — clean install can't launch
`jupyterlab` was pinned only in `[build-system].requires`, so a fresh `pip install langstage-jupyter` left the user with **no Lab UI**, and the headline launcher (`jupyter lab`) died with `Jupyter command 'jupyter-lab' not found`. The launcher's `except FileNotFoundError` guard never fired — the `jupyter` dispatcher *is* present (ships with `jupyter_server`); only the `jupyter-lab` subcommand is missing.

- Declare **`jupyterlab>=4.0.0,<5`** in `[project].dependencies`.
- Launcher now pre-checks `importlib.util.find_spec("jupyterlab")` and prints an actionable `pip install jupyterlab` hint before launching.

## #23 — default agent name 400s OpenAI-compatible providers
The shipped default `name="Default Agent"` flows into the LLM message `name` field, which OpenAI-compatible providers (e.g. via OpenRouter) require to match `^[^\s<|\/>]+$` — **no spaces** — so the default agent hard-`400`'d on the second turn.

- Rename the shipped default to **`default-agent`**.
- Bump the core pin to **`langgraph-stream-parser>=0.6.3`**, which slugifies any unsafe display name (root-cause fix shipped upstream in dkedar7/langgraph-stream-parser#28, released as 0.6.3) — the backstop for everyone's custom agents.

## Tests / CI
- New `tests/test_bug_regressions.py`: default name is provider-safe; core floor is `>=0.6.3`; `jupyterlab` is a declared runtime dep; the launcher guard exits with the hint when JupyterLab is absent and passes when present. (70 passed locally.)
- `test` job now installs `jupyterlab` and pins `langgraph-stream-parser>=0.6.3` to match pyproject.

Closes #23
Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)