### PR TITLE
fix: honor langstage.toml + canonical env in agent; launch via sys.executable (0.5.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.5.4 - 2026-06-20
+
+### Fixed
+- **`langstage.toml` was silently ignored by the default agent (gh #-dogfood).**
+  The module-level config constants were resolved with `use_toml=False`, so the
+  agent ran on env+defaults while `--show-config` advertised `langstage.toml` as a
+  live source. The constants now resolve with TOML on, matching `--show-config`.
+- **Canonical `LANGSTAGE_EXECUTE_TIMEOUT` was ignored** (only the deprecated
+  `DEEPAGENT_EXECUTE_TIMEOUT` worked). `EXECUTE_TIMEOUT` now comes from the
+  resolved `LabConfig` (canonical env + legacy + TOML), and the `get_config()`
+  helper checks the canonical `LANGSTAGE_*` name first.
+- **Workspace-root env precedence was inverted** — `agent.py` read
+  `DEEPAGENT_WORKSPACE_ROOT` directly *before* the resolved config, so the legacy
+  name overrode the canonical `LANGSTAGE_WORKSPACE_ROOT`. It now defers to the
+  resolved `config.WORKSPACE_ROOT` (canonical wins, legacy warns).
+- **Launcher booted the wrong Jupyter (gh #-dogfood).** It shelled out to a bare
+  `jupyter` from `PATH`; when another Jupyter preceded the venv on `PATH` (common
+  on Windows), the chat extension silently never loaded. It now launches via this
+  interpreter (`sys.executable -m jupyterlab`), guaranteeing the env that owns the
+  labextension + server-config.
+- **`langstage-jupyter --version`** reported JupyterLab's version (it was passed
+  through to `jupyter lab`); it now prints this package's version and exits.
+
 ## 0.5.3 - 2026-06-18
 
 ### Fixed

--- a/langstage_jupyter/agent.py
+++ b/langstage_jupyter/agent.py
@@ -29,11 +29,12 @@ kernel_clients = {}
 
 # === Configuration ===
 
-# Get workspace root from environment or config
-workspace_root = os.getenv('DEEPAGENT_WORKSPACE_ROOT')
-if workspace_root:
-    WORKSPACE = Path(workspace_root)
-elif config.WORKSPACE_ROOT:
+# Workspace root comes from the resolved config (config.WORKSPACE_ROOT honors
+# canonical LANGSTAGE_WORKSPACE_ROOT, legacy DEEPAGENT_WORKSPACE_ROOT, and
+# langstage.toml with the correct precedence). Reading DEEPAGENT_WORKSPACE_ROOT
+# directly here used to override the canonical name — precedence inversion fixed
+# by deferring to config (gh #-dogfood).
+if config.WORKSPACE_ROOT:
     WORKSPACE = config.WORKSPACE_ROOT
 else:
     WORKSPACE = Path(".")
@@ -47,8 +48,10 @@ MODEL_NAME = config.MODEL_NAME
 MODEL_TEMPERATURE = config.MODEL_TEMPERATURE
 
 # Total seconds to wait for a single cell to finish executing before reporting
-# possibly-incomplete output. Override via DEEPAGENT_EXECUTE_TIMEOUT.
-EXECUTE_TIMEOUT = config.get_config("execute_timeout", default=300.0, type_cast=float)
+# possibly-incomplete output. From the resolved config so LANGSTAGE_EXECUTE_TIMEOUT
+# (canonical), DEEPAGENT_EXECUTE_TIMEOUT (legacy), and jupyter.execute_timeout in
+# langstage.toml all apply.
+EXECUTE_TIMEOUT = config.EXECUTE_TIMEOUT
 
 # === Tool Definitions ===
 

--- a/langstage_jupyter/config.py
+++ b/langstage_jupyter/config.py
@@ -16,13 +16,15 @@ from langgraph_stream_parser.host import HostConfig, load_toml_config  # noqa: F
 
 
 def get_config(key: str, default: Any = None, type_cast: Optional[Callable] = None) -> Any:
-    """Get a config value from a ``DEEPAGENT_{KEY}`` env var (env-only helper).
+    """Get a config value from env, canonical ``LANGSTAGE_{KEY}`` first.
 
-    Priority: env var ``DEEPAGENT_{KEY}`` > default. Retained for ad-hoc keys
-    (e.g. ``execute_timeout``) and back-compat.
+    Priority: ``LANGSTAGE_{KEY}`` > legacy ``DEEPAGENT_{KEY}`` > default. The
+    canonical spelling must work — it's what ``--show-config`` advertises — so
+    this no longer reads only the legacy name (gh #-dogfood).
     """
-    env_key = f"DEEPAGENT_{key.upper()}"
-    env_value = os.getenv(env_key)
+    canonical = os.getenv(f"LANGSTAGE_{key.upper()}")
+    legacy = os.getenv(f"DEEPAGENT_{key.upper()}")
+    env_value = canonical if canonical is not None else legacy
     if env_value is not None:
         return type_cast(env_value) if type_cast else env_value
     return default
@@ -72,10 +74,12 @@ class LabConfig(HostConfig):
     }
 
 
-# Module-level constants — an env + defaults view (no TOML) derived from
-# LabConfig, for back-compat with call sites that read ``config.X``. Full
-# TOML-aware resolution is ``LabConfig.resolve()`` (used by the launcher).
-_cfg = LabConfig.resolve(use_toml=False)
+# Module-level constants derived from LabConfig, for call sites that read
+# ``config.X`` (agent.py, agent_wrapper.py). TOML is ON so these honor
+# ``langstage.toml`` — the same resolution ``--show-config`` advertises.
+# Previously this used ``use_toml=False``, so the default agent silently ignored
+# langstage.toml while --show-config presented it as a live source (gh #-dogfood).
+_cfg = LabConfig.resolve()
 
 WORKSPACE_ROOT: Optional[Path] = (
     _cfg.workspace_root.resolve()
@@ -91,3 +95,7 @@ MODEL_NAME = _cfg.model_name
 MODEL_TEMPERATURE = _cfg.model_temperature
 DEBUG = _cfg.debug
 VIRTUAL_MODE = _cfg.virtual_mode
+# Resolved through LabConfig so canonical LANGSTAGE_EXECUTE_TIMEOUT and
+# jupyter.execute_timeout in langstage.toml both apply (the old get_config()
+# read only DEEPAGENT_EXECUTE_TIMEOUT). agent.py reads this constant.
+EXECUTE_TIMEOUT = _cfg.execute_timeout

--- a/langstage_jupyter/launcher.py
+++ b/langstage_jupyter/launcher.py
@@ -102,6 +102,17 @@ def main():
     # Parse command line arguments
     args = sys.argv[1:]
 
+    # --version: report THIS package's version and exit. Passing it through to
+    # `jupyter lab` printed JupyterLab's version instead (gh #-dogfood).
+    if "--version" in args or "-V" in args:
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            print(f"langstage-jupyter {version('langstage-jupyter')}")
+        except PackageNotFoundError:  # pragma: no cover
+            print("langstage-jupyter 0.0.0+local")
+        return
+
     # --show-config: print the resolved config (value, source, env var / TOML
     # key for each) and exit — no need to remember the DEEPAGENT_* names.
     if "--show-config" in args:
@@ -185,8 +196,12 @@ def main():
     print(f"    - LANGSTAGE_JUPYTER_TOKEN")
     print(f"{'='*60}\n")
 
-    # Build jupyter lab command
-    jupyter_args = ['jupyter', 'lab']
+    # Launch JupyterLab via THIS interpreter (sys.executable -m jupyterlab),
+    # not a bare `jupyter` resolved from PATH. The labextension + server-config
+    # are installed into this environment; if another Jupyter sits earlier on
+    # PATH (common on Windows with a user-site Python), `jupyter lab` boots the
+    # wrong app and the chat sidebar silently never loads (gh #-dogfood).
+    jupyter_args = [sys.executable, '-m', 'jupyterlab']
 
     # Add port if not already specified by user
     if not port_specified:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/tests/test_canonical_config.py
+++ b/tests/test_canonical_config.py
@@ -1,0 +1,92 @@
+"""Regressions for the canonical-env / TOML config bugs (dogfood clusters 2+3).
+
+- Canonical ``LANGSTAGE_*`` env vars must take effect (not only legacy
+  ``DEEPAGENT_*``), including ``execute_timeout`` (was read via a DEEPAGENT-only
+  helper) and ``workspace_root`` (was read with inverted precedence).
+- The module-level constants in ``config.py`` (which the default agent reads)
+  must honor ``langstage.toml`` — the same resolution ``--show-config`` shows.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from langstage_jupyter.config import LabConfig, get_config
+
+
+# ── resolve(): canonical LANGSTAGE_* env ─────────────────────────────
+
+
+def test_canonical_env_sets_execute_timeout():
+    cfg = LabConfig.resolve(env={"LANGSTAGE_EXECUTE_TIMEOUT": "42"}, use_toml=False)
+    assert cfg.execute_timeout == 42.0
+
+
+def test_canonical_env_beats_legacy():
+    cfg = LabConfig.resolve(
+        env={
+            "LANGSTAGE_MODEL_NAME": "openai:canonical",
+            "DEEPAGENT_MODEL_NAME": "openai:legacy",
+        },
+        use_toml=False,
+    )
+    assert cfg.model_name == "openai:canonical"
+
+
+def test_legacy_env_still_resolves():
+    cfg = LabConfig.resolve(env={"DEEPAGENT_EXECUTE_TIMEOUT": "99"}, use_toml=False)
+    assert cfg.execute_timeout == 99.0
+
+
+# ── get_config(): canonical first, legacy fallback ───────────────────
+
+
+def test_get_config_prefers_canonical(monkeypatch):
+    monkeypatch.setenv("LANGSTAGE_EXECUTE_TIMEOUT", "5")
+    monkeypatch.setenv("DEEPAGENT_EXECUTE_TIMEOUT", "9")
+    assert get_config("execute_timeout", type_cast=float) == 5.0
+
+
+def test_get_config_legacy_fallback(monkeypatch):
+    monkeypatch.delenv("LANGSTAGE_EXECUTE_TIMEOUT", raising=False)
+    monkeypatch.setenv("DEEPAGENT_EXECUTE_TIMEOUT", "9")
+    assert get_config("execute_timeout", type_cast=float) == 9.0
+
+
+# ── module constants (import-time) honor canonical env + TOML ────────
+#
+# config.py's constants are computed at import, so these run a subprocess with
+# the env / cwd set up first — exactly the dogfood repro shape.
+
+
+def _agent_const(name: str, *, env: dict | None = None, cwd: Path | None = None) -> str:
+    full_env = dict(os.environ)
+    # Strip any inherited config env so the subprocess starts clean.
+    for k in list(full_env):
+        if k.startswith(("LANGSTAGE_", "DEEPAGENT_")):
+            del full_env[k]
+    full_env.update(env or {})
+    out = subprocess.run(
+        [sys.executable, "-c", f"import langstage_jupyter.agent as a; print(a.{name})"],
+        capture_output=True,
+        text=True,
+        env=full_env,
+        cwd=str(cwd) if cwd else None,
+    )
+    assert out.returncode == 0, out.stderr
+    return out.stdout.strip()
+
+
+def test_module_execute_timeout_honors_canonical_env():
+    assert _agent_const("EXECUTE_TIMEOUT", env={"LANGSTAGE_EXECUTE_TIMEOUT": "42"}) == "42.0"
+
+
+def test_module_constants_honor_langstage_toml(tmp_path):
+    (tmp_path / "langstage.toml").write_text(
+        '[model]\nname = "anthropic:toml-model"\n[jupyter]\nexecute_timeout = 123.0\n',
+        encoding="utf-8",
+    )
+    assert _agent_const("MODEL_NAME", cwd=tmp_path) == "anthropic:toml-model"
+    assert _agent_const("EXECUTE_TIMEOUT", cwd=tmp_path) == "123.0"


### PR DESCRIPTION
Config + launcher cluster from the comprehensive dogfood run (3 majors + 2 minors).

## Config: advertised ≠ honored, canonical env dead (3 majors / minors)
- **`langstage.toml` ignored by the default agent.** The module config constants were resolved with `use_toml=False`, so the agent ran on env+defaults while `--show-config` presented `langstage.toml` as a live source. Now resolved with TOML on — agent matches `--show-config`.
- **`LANGSTAGE_EXECUTE_TIMEOUT` ignored** (only `DEEPAGENT_EXECUTE_TIMEOUT` worked). `EXECUTE_TIMEOUT` now comes from the resolved `LabConfig` (canonical env + legacy + TOML); `get_config()` checks `LANGSTAGE_*` first.
- **Workspace-root precedence inverted** — `agent.py` read `DEEPAGENT_WORKSPACE_ROOT` directly *before* the resolved config, so the legacy name beat canonical `LANGSTAGE_WORKSPACE_ROOT`. Now defers to `config.WORKSPACE_ROOT`.

## Launcher (1 major + 1 minor)
- **Booted the wrong Jupyter.** Shelled out to a bare `jupyter` from `PATH`; when another Jupyter preceded the venv on `PATH` (common on Windows with a user-site Python), `jupyter lab` launched the wrong app and the chat sidebar silently never loaded. Now launches via `sys.executable -m jupyterlab` — the env that owns the labextension + server-config.
- **`--version`** printed JupyterLab's version (passed through to `jupyter lab`); now prints this package's version and exits.

## Tests
New `tests/test_canonical_config.py` — resolve-level canonical env, `get_config` canonical-first, and **subprocess tests** for the import-time module constants (the exact dogfood repros: `LANGSTAGE_EXECUTE_TIMEOUT` and a `langstage.toml` both now take effect). **77 passed.**

Deferred (lower-value, noted): `--help` still shows JupyterLab's help; the `agent_wrapper.set_root_dir` dead-import path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)