### PR TITLE
fix: launcher --help/--show-config flags + canonical env-var text (0.5.5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,128 +1,71 @@
 # ============================================================================
-# deepagent Configuration
+# langstage-jupyter configuration
 # ============================================================================
-# Copy this file to .env and customize for your environment
+# Copy this file to .env and customize for your environment.
 #
-# IMPORTANT: This configuration is compatible with both deepagent-lab and
-# deepagent-dash. Agents can be shared between the two libraries.
-#
+# All configuration uses the canonical LANGSTAGE_ prefix. The pre-rename
+# DEEPAGENT_ names still resolve as deprecated fallbacks (canonical wins).
 # ============================================================================
 
 # ============================================================================
-# API Keys (Required)
+# API Keys (Required for a real agent)
 # ============================================================================
 
-# Anthropic API Key for Claude models
-# Get your API key from: https://console.anthropic.com/
+# Anthropic API key for Claude models — https://console.anthropic.com/
 ANTHROPIC_API_KEY=your-anthropic-api-key-here
 
 # ============================================================================
-# LangSmith Configuration (Optional - for debugging and tracing)
+# LangSmith (Optional — debugging and tracing)
 # ============================================================================
-
-# LangSmith API Key
-# Get your API key from: https://smith.langchain.com/
 LANGSMITH_API_KEY=your-langsmith-api-key-here
-
-# LangSmith Project Name
-LANGSMITH_PROJECT=deepagent-lab
-
-# Enable/disable LangSmith tracing
+LANGSMITH_PROJECT=langstage-jupyter
 LANGSMITH_TRACING=true
 
 # ============================================================================
-# DeepAgent Configuration
-# All deepagent variables use the DEEPAGENT_ prefix
-# These settings work for both deepagent-lab and deepagent-dash
+# langstage-jupyter settings (LANGSTAGE_* prefix)
 # ============================================================================
 
-# --- Workspace Configuration ---
+# --- Workspace ---
+# Root directory for agent filesystem operations (defaults to the app root).
+#LANGSTAGE_WORKSPACE_ROOT=/Users/you/projects/my-project
 
-# Root directory for agent filesystem operations
-# Defaults to application root directory if not set
-# Example: /Users/username/projects/my-project
-#DEEPAGENT_WORKSPACE_ROOT=
+# --- Agent ---
+# Agent spec: "module:variable" or "path/to/file.py:variable".
+#   LANGSTAGE_AGENT_SPEC=langstage_jupyter.agent:agent
+#   LANGSTAGE_AGENT_SPEC=./my_custom_agent.py:graph
+#LANGSTAGE_AGENT_SPEC=
 
-# --- Agent Configuration ---
+# Or specify module + variable separately:
+#LANGSTAGE_AGENT_MODULE=my_agents.notebook
+#LANGSTAGE_AGENT_VARIABLE=agent
 
-# Agent spec in format "module_path:variable_name" or "file_path:variable_name"
-# This is compatible with both deepagent-lab and deepagent-dash
-# Examples:
-#   DEEPAGENT_AGENT_SPEC=deepagent_lab.agent:agent
-#   DEEPAGENT_AGENT_SPEC=./my_custom_agent.py:my_agent
-#   DEEPAGENT_AGENT_SPEC=/abs/path/to/agent.py:graph
-#DEEPAGENT_AGENT_SPEC=
+# --- Jupyter server ---
+LANGSTAGE_JUPYTER_SERVER_URL=http://localhost:8889
+# Must match the token JupyterLab is launched with.
+# Generate one: python3 -c "import secrets; print(secrets.token_hex(16))"
+LANGSTAGE_JUPYTER_TOKEN=change-me
 
-# Alternatively, specify module and variable separately
-# Module path (e.g., "my_agents.notebook") or file path (e.g., "./my_agent.py")
-#DEEPAGENT_AGENT_MODULE=deepagent_lab.agent
+# --- Model ---
+LANGSTAGE_MODEL_NAME=anthropic:claude-sonnet-4-6
+# Temperature 0.0–1.0 (lower = more focused/deterministic).
+LANGSTAGE_MODEL_TEMPERATURE=0.0
 
-# Variable name to load from module (optional, defaults to 'agent' or 'graph')
-#DEEPAGENT_AGENT_VARIABLE=agent
+# --- Backend ---
+# Virtual mode for the FilesystemBackend: true = validated/sandboxed, false = direct.
+LANGSTAGE_VIRTUAL_MODE=true
 
-# --- Jupyter Server Configuration ---
+# --- Execution ---
+# Seconds to wait for a single cell to finish before reporting partial output.
+#LANGSTAGE_EXECUTE_TIMEOUT=300
 
-# Jupyter server URL
-DEEPAGENT_JUPYTER_SERVER_URL=http://localhost:8889
-
-# Jupyter authentication token
-# Must match the token used when starting JupyterLab
-# Generate a new random token: python3 -c "import secrets; print(secrets.token_hex(16))"
-DEEPAGENT_JUPYTER_TOKEN=8e2121e58cd3f9e13fc05fc020955c6e
-
-# --- Model Configuration ---
-
-# Model to use (Anthropic models)
-# Options: anthropic:claude-sonnet-4-20250514, anthropic:claude-opus-4-20250514, etc.
-DEEPAGENT_MODEL_NAME=anthropic:claude-sonnet-4-20250514
-
-# Model temperature (0.0 to 1.0)
-# Lower values make output more focused and deterministic
-DEEPAGENT_MODEL_TEMPERATURE=0.0
-
-# --- Backend Configuration ---
-
-# Enable virtual mode for FilesystemBackend
-# true = safe mode (operations are validated but not always persistent)
-# false = direct filesystem access
-DEEPAGENT_VIRTUAL_MODE=true
-
-# --- Debug Configuration ---
-
-# Enable debug mode (true, 1, yes for enabled, anything else for disabled)
-DEEPAGENT_DEBUG=false
+# --- Debug ---
+LANGSTAGE_DEBUG=false
 
 # ============================================================================
 # Notes
 # ============================================================================
-#
-# 1. Cross-Library Compatibility:
-#    - All DEEPAGENT_* variables work with both deepagent-lab and deepagent-dash
-#    - You can develop an agent once and use it in both environments
-#    - Workspace discovery works automatically in both libraries
-#
-# 2. Environment Variable Priority:
-#    - Environment variables override all default values
-#    - DEEPAGENT_AGENT_SPEC takes precedence over separate module+variable
-#
-# 3. Agent Spec Examples:
-#    - Load from installed package:
-#      DEEPAGENT_AGENT_SPEC=my_agents.notebook:agent
-#
-#    - Load from file in current directory:
-#      DEEPAGENT_AGENT_SPEC=./custom_agent.py:agent
-#
-#    - Load from absolute path:
-#      DEEPAGENT_AGENT_SPEC=/home/user/agents/my_agent.py:graph
-#
-# 4. Workspace Configuration:
-#    - If not set, defaults to application root directory
-#    - Agents access this via os.getenv('DEEPAGENT_WORKSPACE_ROOT')
-#    - Works the same in deepagent-lab and deepagent-dash
-#
-# 5. Security:
-#    - NEVER commit this file with real API keys
-#    - Add .env to your .gitignore
-#    - Use this .env.example as a template only
-#
+# 1. Precedence: env vars override defaults; LANGSTAGE_AGENT_SPEC wins over the
+#    separate module + variable. langstage.toml is read too (see --show-config).
+# 2. The legacy DEEPAGENT_* names still work as deprecated fallbacks.
+# 3. Security: never commit a real .env; keep .env in .gitignore; this is a template.
 # ============================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.5.5 - 2026-06-21
+
+### Fixed
+- **`langstage-jupyter --help`** passed straight through to `jupyter lab` and never
+  documented the launcher's own flags (`--demo`, `-a/--agent`, `--show-config`,
+  `--version`). It now prints a short launcher usage block (ASCII-only, so it can't
+  mojibake on a cp1252 console) and points at `jupyter lab --help` for the rest.
+- **`--show-config` ignored `-a/--agent` and `--demo`** (it short-circuited before
+  parsing them, always reporting `agent_spec=None`). Agent flags are now parsed
+  first, so `--show-config` reflects the agent the same invocation would launch.
+- **The cell-timeout warning** told users to set the deprecated
+  `DEEPAGENT_EXECUTE_TIMEOUT`; it now names the canonical `LANGSTAGE_EXECUTE_TIMEOUT`.
+
+### Docs
+- Regenerated `.env.example` with canonical `LANGSTAGE_*` names (it was 100%
+  pre-rename `DEEPAGENT_*` and referenced the old `deepagent-lab`/`deepagent-dash`
+  identity), aligned to the current default model.
+
 ## 0.5.4 - 2026-06-20
 
 ### Fixed

--- a/langstage_jupyter/agent.py
+++ b/langstage_jupyter/agent.py
@@ -453,7 +453,7 @@ def execute_cell(
     if timed_out:
         output_texts.append(
             f"[langstage-jupyter] Cell exceeded EXECUTE_TIMEOUT={EXECUTE_TIMEOUT}s; "
-            "output above may be incomplete. Set DEEPAGENT_EXECUTE_TIMEOUT to raise the budget."
+            "output above may be incomplete. Set LANGSTAGE_EXECUTE_TIMEOUT to raise the budget."
         )
     
     # Update cell in notebook

--- a/langstage_jupyter/launcher.py
+++ b/langstage_jupyter/launcher.py
@@ -26,6 +26,22 @@ import subprocess
 # The keyless echo agent shipped with the shared core — see `--demo`.
 DEMO_AGENT_SPEC = "langgraph_stream_parser.demo.stub:graph"
 
+_LAUNCHER_HELP = """\
+langstage-jupyter - launch JupyterLab with the LangStage chat sidebar.
+
+Usage:
+  langstage-jupyter [launcher options] [jupyter lab options...]
+
+Launcher options:
+  -a, --agent SPEC   Agent to load (module:attr or path/to/file.py:attr).
+  --demo             Use the built-in keyless demo agent (no API key).
+  --show-config      Print the resolved configuration and exit.
+  --version, -V      Print the langstage-jupyter version and exit.
+  -h, --help         Show this message and exit.
+
+All other options are passed through to `jupyter lab`
+(run `jupyter lab --help` to see those)."""
+
 
 def ensure_jupyterlab():
     """Fail fast with an actionable hint if JupyterLab isn't importable.
@@ -102,6 +118,13 @@ def main():
     # Parse command line arguments
     args = sys.argv[1:]
 
+    # --help / -h: show the LAUNCHER's own flags. Otherwise --help passes through
+    # to `jupyter lab`, which dumps JupyterLab's help and never mentions
+    # --demo / -a / --show-config / --version (gh #-dogfood).
+    if "--help" in args or "-h" in args:
+        print(_LAUNCHER_HELP)
+        return
+
     # --version: report THIS package's version and exit. Passing it through to
     # `jupyter lab` printed JupyterLab's version instead (gh #-dogfood).
     if "--version" in args or "-V" in args:
@@ -113,19 +136,10 @@ def main():
             print("langstage-jupyter 0.0.0+local")
         return
 
-    # --show-config: print the resolved config (value, source, env var / TOML
-    # key for each) and exit — no need to remember the DEEPAGENT_* names.
-    if "--show-config" in args:
-        from langstage_jupyter.config import LabConfig
-        print(LabConfig.resolve().describe())
-        return
-
-    # Headline command runs `jupyter lab` — bail with a clear hint up front if
-    # JupyterLab isn't installed, instead of letting the jupyter dispatcher dump
-    # its help later (gh #24).
-    ensure_jupyterlab()
-
-    # Our agent flags must not reach `jupyter lab` (it would reject them).
+    # Parse our agent flags FIRST (strip them from args, set env) so --show-config
+    # reflects the agent the same invocation would launch. Previously --show-config
+    # short-circuited before this and always reported agent_spec=None even with
+    # -a/--demo (gh #-dogfood).
     agent_spec, demo, args = extract_agent_args(args)
     if demo and agent_spec:
         print("ERROR: --demo and -a/--agent are mutually exclusive")
@@ -139,7 +153,21 @@ def main():
         # keeps working with this launcher.
         os.environ["LANGSTAGE_AGENT_SPEC"] = agent_spec
         os.environ["DEEPAGENT_AGENT_SPEC"] = agent_spec
+
+    # --show-config: print the resolved config (value, source, env var / TOML
+    # key for each) and exit — now reflecting any -a/--demo parsed above.
+    if "--show-config" in args:
+        from langstage_jupyter.config import LabConfig
+        print(LabConfig.resolve().describe())
+        return
+
+    if agent_spec:
         print(f"Agent spec: {agent_spec}")
+
+    # Headline command runs `jupyter lab` — bail with a clear hint up front if
+    # JupyterLab isn't installed, instead of letting the jupyter dispatcher dump
+    # its help later (gh #24).
+    ensure_jupyterlab()
 
     # Check if user specified a port
     user_port = None

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -74,6 +74,31 @@ class TestMainAgentWiring:
             main()
 
 
+class TestLauncherHelpAndShowConfig:
+    """--help shows the launcher's own flags; --show-config reflects -a/--demo."""
+
+    def test_help_lists_launcher_flags(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["langstage-jupyter", "--help"])
+        main()
+        out = capsys.readouterr().out
+        assert "--demo" in out
+        assert "--show-config" in out
+        assert "--agent" in out
+        assert "jupyter lab" in out  # notes the passthrough
+        # ASCII-only so it doesn't mojibake on a cp1252 console.
+        assert out.isascii(), "launcher help must be ASCII-safe"
+
+    def test_show_config_reflects_agent_flag(self, monkeypatch, capsys):
+        monkeypatch.setenv("LANGSTAGE_AGENT_SPEC", "")
+        monkeypatch.setenv("DEEPAGENT_AGENT_SPEC", "")
+        monkeypatch.setattr(
+            "sys.argv", ["langstage-jupyter", "--show-config", "-a", "foo.py:graph"]
+        )
+        main()
+        out = capsys.readouterr().out
+        assert "foo.py:graph" in out  # not agent_spec=None
+
+
 class TestFindAvailablePort:
     """Tests for find_available_port function."""
 


### PR DESCRIPTION
jupyter minors from the dogfood re-run.

- **`langstage-jupyter --help`** was passed straight through to `jupyter lab` (dumping JupyterLab's help) and never documented the launcher's own flags. It now prints a short launcher usage block listing `-a/--agent`, `--demo`, `--show-config`, `--version` and notes that all other args pass to `jupyter lab`. ASCII-only so it can't mojibake on a cp1252 console.
- **`--show-config` ignored `-a/--agent` and `--demo`** — it short-circuited *before* parsing them, so it always printed `agent_spec=None` even when the same invocation would launch that agent. Agent flags are now parsed first; `--show-config` reflects them.
- **The cell-timeout runtime warning** steered users at the deprecated `DEEPAGENT_EXECUTE_TIMEOUT`; it now names the canonical `LANGSTAGE_EXECUTE_TIMEOUT`.
- **Regenerated `.env.example`** — it was 100% pre-rename `DEEPAGENT_*` and referenced the old `deepagent-lab`/`deepagent-dash` identity. Now canonical `LANGSTAGE_*`, current default model, with a note that legacy names still resolve.

Tests added. **79 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)