### PR TITLE
fix: publish canonical LANGSTAGE_WORKSPACE_ROOT at the JupyterLab hand-off (0.5.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.6 - 2026-06-22
+
+### Fixed
+- **JupyterLab → agent workspace hand-off only set the *legacy* env name.**
+  `AgentWrapper.set_root_dir()` published the live JupyterLab root as
+  `DEEPAGENT_WORKSPACE_ROOT` only, but the README's own custom-agent example
+  (and the documented env table) read the canonical `LANGSTAGE_WORKSPACE_ROOT`.
+  A user following the docs verbatim got `'.'` instead of their notebook project
+  directory. The agent's *read* path was renamed in 0.5.4, but this *write* path
+  still published the deprecated name. It now sets both (canonical + legacy).
+  (Found by the dogfood routine.)
+
 ## 0.5.5 - 2026-06-21
 
 ### Fixed

--- a/langstage_jupyter/agent_wrapper.py
+++ b/langstage_jupyter/agent_wrapper.py
@@ -115,12 +115,19 @@ class AgentWrapper:
     def set_root_dir(self, root_dir: str):
         """
         Set the root directory on the agent's backend if it has one.
-        Also sets the DEEPAGENT_WORKSPACE_ROOT environment variable.
+        Also publishes the workspace root as an environment variable for agents
+        to discover.
 
         Args:
             root_dir: The root directory path (JupyterLab launch directory)
         """
-        # Set environment variable for agents to discover
+        # Publish BOTH the canonical and the legacy env name. The README's own
+        # custom-agent example reads canonical `LANGSTAGE_WORKSPACE_ROOT`, so a
+        # user following the docs verbatim would otherwise see "." instead of
+        # the live JupyterLab root — the agent's read path was renamed (0.5.4)
+        # but this write path still published only the deprecated name.
+        # (gh #-dogfood)
+        os.environ['LANGSTAGE_WORKSPACE_ROOT'] = root_dir
         os.environ['DEEPAGENT_WORKSPACE_ROOT'] = root_dir
 
         if self.agent and hasattr(self.agent, 'backend'):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,16 +10,21 @@ from unittest.mock import Mock
 @pytest.fixture
 def clean_env(monkeypatch):
     """
-    Fixture that provides a clean environment without DEEPAGENT_* variables.
+    Fixture that provides a clean environment without LANGSTAGE_*/DEEPAGENT_* vars.
+
+    Must clear BOTH vocabularies: the canonical ``LANGSTAGE_*`` names take
+    precedence over the legacy ``DEEPAGENT_*`` ones, so leaving a canonical name
+    set (e.g. ``LANGSTAGE_WORKSPACE_ROOT`` published by a prior ``set_root_dir``
+    call) would override the legacy value a test sets and silently corrupt
+    config resolution.
 
     Usage:
         def test_something(clean_env):
-            # All DEEPAGENT_* env vars are removed
+            # All LANGSTAGE_*/DEEPAGENT_* env vars are removed
             pass
     """
-    # Remove all DEEPAGENT_* environment variables
     for key in list(os.environ.keys()):
-        if key.startswith('DEEPAGENT_'):
+        if key.startswith(('LANGSTAGE_', 'DEEPAGENT_')):
             monkeypatch.delenv(key, raising=False)
     return monkeypatch
 

--- a/tests/test_agent_wrapper.py
+++ b/tests/test_agent_wrapper.py
@@ -152,13 +152,16 @@ class TestSetRootDir:
     @patch('langstage_jupyter.agent_wrapper.AgentWrapper._load_agent')
     @patch('os.environ', {})
     def test_sets_environment_variable(self, mock_load):
-        """Should set DEEPAGENT_WORKSPACE_ROOT environment variable."""
+        """Should publish BOTH the canonical and legacy workspace-root env vars."""
         import os
         wrapper = AgentWrapper()
         wrapper.agent = Mock()
 
         wrapper.set_root_dir("/home/user/workspace")
 
+        # Canonical name is what the README's custom-agent example reads.
+        assert os.environ['LANGSTAGE_WORKSPACE_ROOT'] == "/home/user/workspace"
+        # Legacy name stays set for back-compat with anything still reading it.
         assert os.environ['DEEPAGENT_WORKSPACE_ROOT'] == "/home/user/workspace"
 
     @patch('langstage_jupyter.agent_wrapper.AgentWrapper._load_agent')


### PR DESCRIPTION
From the daily library-health dogfood routine.

## The bug
When JupyterLab hands its server root to the agent, `AgentWrapper.set_root_dir()` published it **only** as the legacy `DEEPAGENT_WORKSPACE_ROOT`. But the README's own custom-agent example reads the canonical name:

```python
workspace = os.getenv('LANGSTAGE_WORKSPACE_ROOT', '.')
```

and the documented env-var table lists `LANGSTAGE_WORKSPACE_ROOT` as "Working directory for agent". So a user following the docs verbatim got `'.'` (cwd) instead of their actual notebook project directory — the agent operated on the wrong directory.

This is the residual of the canonical/legacy rename: the agent's **read** path was corrected in 0.5.4, but this **write** path still published only the deprecated name.

## The fix
`set_root_dir()` now sets **both** `LANGSTAGE_WORKSPACE_ROOT` (canonical — what the docs read) and `DEEPAGENT_WORKSPACE_ROOT` (legacy — kept for back-compat).

## Test
`test_sets_environment_variable` now asserts both names are set after `set_root_dir()`. Full suite: 27 passed.
