### PR TITLE
fix: --show-config drops inert host/port rows on the JupyterLab stage (0.5.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.7 - 2026-06-25
+
+### Fixed
+- **`--show-config` advertised `LANGSTAGE_PORT` / `LANGSTAGE_HOST`, which the
+  launcher ignores.** Those keys are inherited from the shared `HostConfig`
+  (real for the web-app stage), but JupyterLab's port is always the
+  auto-detected port or `--port`, and the host is always `localhost`. So
+  `--show-config` reported a value and a "source" env var with zero effect —
+  teaching a wrong mental model ("I set `LANGSTAGE_PORT` but it didn't apply").
+  The two inert rows are now dropped from `--show-config` via core's new
+  `describe(omit_keys=…)` (requires `langgraph-stream-parser>=0.6.11`). (Found
+  by the dogfood routine, gh #30.)
+
 ## 0.5.6 - 2026-06-22
 
 ### Fixed

--- a/langstage_jupyter/launcher.py
+++ b/langstage_jupyter/launcher.py
@@ -158,7 +158,12 @@ def main():
     # key for each) and exit — now reflecting any -a/--demo parsed above.
     if "--show-config" in args:
         from langstage_jupyter.config import LabConfig
-        print(LabConfig.resolve().describe())
+        # Hide the inherited web-app keys this stage doesn't honor: JupyterLab's
+        # port is the auto-detected port or --port (never LANGSTAGE_PORT), and
+        # the host is always localhost. Advertising them with an env-var source
+        # taught a wrong mental model ("I set LANGSTAGE_PORT but it didn't
+        # apply"). (gh #30)
+        print(LabConfig.resolve().describe(omit_keys=["host", "port"]))
         return
 
     if agent_spec:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,10 @@ dependencies = [
     "jupyterlab>=4.0.0,<5",
     "jupyter_server>=2.0.1,<3",
     "langgraph>=0.0.1",
-    # >=0.6.3 carries the agent-name slugify fix that keeps OpenAI-compatible
-    # providers from 400ing on a display name with a space (gh #23).
-    "langgraph-stream-parser>=0.6.3,<0.7",
+    # >=0.6.11 carries describe(omit_keys=...) (so --show-config can hide the
+    # inherited host/port rows this stage doesn't honor); also the agent-name
+    # slugify fix (gh #23) and BOM-safe TOML.
+    "langgraph-stream-parser>=0.6.11,<0.7",
     "python-dotenv>=0.19.0",
     "deepagents>=0.1.0",
     # Direct top-level imports in langstage_jupyter/agent.py. Previously only
@@ -59,7 +60,7 @@ dev = [
     "pytest-cov>=4.0.0",
     "pytest-asyncio>=0.21.0",
 ]
-agui = ["langgraph-stream-parser[agui]>=0.6.3,<0.7"]
+agui = ["langgraph-stream-parser[agui]>=0.6.11,<0.7"]
 
 [tool.hatch.version]
 source = "nodejs"

--- a/tests/test_bug_regressions.py
+++ b/tests/test_bug_regressions.py
@@ -45,10 +45,18 @@ def test_default_agent_name_is_provider_safe():
 
 
 def test_core_floor_carries_slugify_fix():
-    """#23: the core dep floor must be >=0.6.3 (where the slugify fix landed)."""
+    """#23: the core dep floor must be >=0.6.3 (where the slugify fix landed).
+
+    Parse the lower bound rather than substring-match a literal, so routine
+    floor bumps (e.g. >=0.6.11 for describe(omit_keys)) don't trip this guard.
+    """
+    import re
+
     deps = _PYPROJECT["project"]["dependencies"]
     core = next(d for d in deps if d.lower().startswith("langgraph-stream-parser"))
-    assert ">=0.6.3" in core, core
+    m = re.search(r">=\s*(\d+)\.(\d+)\.(\d+)", core)
+    assert m, core
+    assert tuple(int(g) for g in m.groups()) >= (0, 6, 3), core
 
 
 def test_jupyterlab_is_a_declared_runtime_dependency():

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -98,6 +98,22 @@ class TestLauncherHelpAndShowConfig:
         out = capsys.readouterr().out
         assert "foo.py:graph" in out  # not agent_spec=None
 
+    def test_show_config_omits_inert_host_port(self, monkeypatch, capsys):
+        # The launcher never honors LANGSTAGE_HOST/PORT (JupyterLab uses --port /
+        # auto-detect and binds localhost), so --show-config must not advertise
+        # them with a live env-var source. (gh #30)
+        monkeypatch.setenv("LANGSTAGE_PORT", "7777")
+        monkeypatch.setenv("LANGSTAGE_HOST", "0.0.0.0")
+        monkeypatch.setattr("sys.argv", ["langstage-jupyter", "--show-config"])
+        main()
+        out = capsys.readouterr().out
+        assert "LANGSTAGE_PORT" not in out
+        assert "LANGSTAGE_HOST" not in out
+        assert "\n  port " not in out
+        assert "\n  host " not in out
+        # ...but keys this stage actually honors are still shown.
+        assert "agent_spec" in out
+
 
 class TestFindAvailablePort:
     """Tests for find_available_port function."""


### PR DESCRIPTION
From the daily dogfood routine (Fixes #30).

The launcher never honors `LANGSTAGE_HOST` / `LANGSTAGE_PORT` — JupyterLab's port is the auto-detected port (from 8888) or `--port`, and the host is always `localhost`. But these keys are inherited from the shared `HostConfig` (where they're real for the web-app stage), so `--show-config` printed them with a confident env-var source attribution that has zero effect here. A user who sets `LANGSTAGE_PORT`, runs `--show-config` to confirm it "took", then gets a different port.

Now dropped from `--show-config` via core's new `describe(omit_keys=["host","port"])` (bumps the core floor to `>=0.6.11`). The keys this stage actually honors (`agent_spec`, `workspace_root`, the Jupyter-specific keys) are unchanged; the real port control (`--port`) is unaffected.

**Test:** `--show-config` with `LANGSTAGE_PORT`/`LANGSTAGE_HOST` set shows neither the rows nor the env vars, and still shows `agent_spec`.
