### PR TITLE
fix: resolve .env from the launch cwd, not the installed package (0.5.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.8 - 2026-06-26
+
+### Fixed
+- **`.env` files were silently ignored at runtime.** `agent.py` and
+  `agent_wrapper.py` called a bare `load_dotenv()`, which searches upward from
+  the calling module — inside `site-packages` once installed — so a user's
+  project `.env` (the documented "create a `.env` file" path, and the whole
+  point of `.env.example`) was never found, and every setting in it silently
+  fell back to defaults. Both now resolve via `load_dotenv(find_dotenv(usecwd=True))`,
+  anchoring `.env` to the launch directory (matching how `langstage.toml` is
+  already discovered). Exported shell env vars were unaffected. (Found by the
+  dogfood routine, gh #32.)
+
 ## 0.5.7 - 2026-06-25
 
 ### Fixed

--- a/langstage_jupyter/agent.py
+++ b/langstage_jupyter/agent.py
@@ -10,8 +10,11 @@ import time
 from pathlib import Path
 from typing import Annotated
 
-from dotenv import load_dotenv
-load_dotenv()
+from dotenv import find_dotenv, load_dotenv
+# Resolve .env from the user's working (launch) directory, not the installed
+# package location — a bare load_dotenv() searches from site-packages and never
+# finds the user's project .env. (gh #32)
+load_dotenv(find_dotenv(usecwd=True))
 
 from langgraph_stream_parser.demo import create_default_agent as _build_default_agent
 from langchain.chat_models import init_chat_model

--- a/langstage_jupyter/agent_wrapper.py
+++ b/langstage_jupyter/agent_wrapper.py
@@ -8,8 +8,12 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, Iterator, Optional
 
-from dotenv import load_dotenv
-load_dotenv()
+from dotenv import find_dotenv, load_dotenv
+# Resolve .env from the user's working (launch) directory, not the installed
+# package location. A bare load_dotenv() searches upward from this module inside
+# site-packages, so the user's project .env is never found and silently ignored.
+# (gh #32)
+load_dotenv(find_dotenv(usecwd=True))
 
 # Import configuration
 from . import config

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/tests/test_dotenv_cwd.py
+++ b/tests/test_dotenv_cwd.py
@@ -1,0 +1,28 @@
+"""`.env` is resolved from the launch cwd, not the installed package (gh #32).
+
+A bare `load_dotenv()` searches upward from the calling module — inside
+site-packages once installed — so the user's project `.env` was never found and
+silently ignored. The loader must use `find_dotenv(usecwd=True)`.
+"""
+
+import subprocess
+import sys
+
+
+def test_dotenv_resolved_from_launch_cwd(tmp_path):
+    (tmp_path / ".env").write_text("SENTINEL_FROM_DOTENV=from_env_file\n")
+    # Fresh process whose cwd contains the .env; importing the package runs the
+    # module-level load_dotenv. With the fix it finds tmp_path/.env.
+    r = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import langstage_jupyter.agent_wrapper; import os; "
+            "print(os.environ.get('SENTINEL_FROM_DOTENV', 'MISSING'))",
+        ],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0, r.stderr
+    assert "from_env_file" in r.stdout, f"stdout={r.stdout!r} stderr={r.stderr!r}"


### PR DESCRIPTION
From the daily dogfood routine (Fixes #32).

## The bug (major)
A user who follows the README ("create a `.env` file or export") and copies `.env.example` to `.env` has **every** setting silently ignored at launch. `agent.py` and `agent_wrapper.py` call a bare `load_dotenv()`, whose default `find_dotenv(usecwd=False)` searches upward from the *calling module's* directory — `site-packages/langstage_jupyter/` once installed — not the user's project/launch dir. So the project `.env` is never found, and `ANTHROPIC_API_KEY`, `LANGSTAGE_AGENT_SPEC`, etc. fall back to defaults with no warning.

(It looked fine in quick `python -c` checks only because `-c` has no `__file__`, which makes python-dotenv fall back to cwd — the real console script and Jupyter server process both have a real `__main__.__file__`.)

## The fix
Both call sites now use `load_dotenv(find_dotenv(usecwd=True))`, which searches upward from the launch cwd — anchoring `.env` to where the user runs the command, matching how `langstage.toml` is already discovered. Exported shell env vars were unaffected either way.

## Test
A subprocess importing the package from a directory containing a `.env` now loads the sentinel var (the bare loader would have missed it).

Full suite 81 passed.
