### PR TITLE
fix: --show-config drops more launcher-managed keys (0.5.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.9 - 2026-06-27
+
+### Fixed
+- **`--show-config` advertised more keys the launcher doesn't honor.** Completing
+  the #30 fix: `title` is inherited from the web-app `HostConfig` but read
+  nowhere in this stage, and `jupyter_token` / `jupyter_server_url` are
+  auto-generated/-detected at startup and overridden by the launcher (a
+  user-set `LANGSTAGE_JUPYTER_TOKEN` is silently discarded — pin via the
+  standard `JUPYTER_TOKEN`). All three are now dropped from the launcher's
+  `--show-config` via `describe(omit_keys=…)`, so it only advertises keys this
+  stage actually honors. (Found by the dogfood routine, gh #34.)
+
 ## 0.5.8 - 2026-06-26
 
 ### Fixed

--- a/langstage_jupyter/launcher.py
+++ b/langstage_jupyter/launcher.py
@@ -158,12 +158,17 @@ def main():
     # key for each) and exit — now reflecting any -a/--demo parsed above.
     if "--show-config" in args:
         from langstage_jupyter.config import LabConfig
-        # Hide the inherited web-app keys this stage doesn't honor: JupyterLab's
-        # port is the auto-detected port or --port (never LANGSTAGE_PORT), and
-        # the host is always localhost. Advertising them with an env-var source
-        # taught a wrong mental model ("I set LANGSTAGE_PORT but it didn't
-        # apply"). (gh #30)
-        print(LabConfig.resolve().describe(omit_keys=["host", "port"]))
+        # Hide keys the LAUNCHER doesn't honor, so --show-config never advertises
+        # an env var with a confident source that has no effect here:
+        #   host/port  — JupyterLab binds localhost on the auto-detected/--port port (gh #30)
+        #   title      — inherited from the web-app HostConfig; read nowhere in this stage
+        #   jupyter_token / jupyter_server_url — auto-generated/-detected at startup;
+        #     the launcher overrides whatever was resolved (pin via JUPYTER_TOKEN). (gh #34)
+        print(
+            LabConfig.resolve().describe(
+                omit_keys=["host", "port", "title", "jupyter_token", "jupyter_server_url"]
+            )
+        )
         return
 
     if agent_spec:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -114,6 +114,22 @@ class TestLauncherHelpAndShowConfig:
         # ...but keys this stage actually honors are still shown.
         assert "agent_spec" in out
 
+    def test_show_config_omits_launcher_managed_keys(self, monkeypatch, capsys):
+        # title is read nowhere in this stage; jupyter_token / jupyter_server_url
+        # are auto-generated/-detected and the launcher overrides them — so none
+        # of the three should be advertised with a live source. (gh #34)
+        monkeypatch.setenv("LANGSTAGE_TITLE", "MyTitle")
+        monkeypatch.setenv("LANGSTAGE_JUPYTER_TOKEN", "pinned-tok")
+        monkeypatch.setenv("LANGSTAGE_JUPYTER_SERVER_URL", "http://localhost:9999")
+        monkeypatch.setattr("sys.argv", ["langstage-jupyter", "--show-config"])
+        main()
+        out = capsys.readouterr().out
+        for key in ("\n  title ", "\n  jupyter_token ", "\n  jupyter_server_url "):
+            assert key not in out, key
+        for env in ("LANGSTAGE_TITLE", "LANGSTAGE_JUPYTER_TOKEN", "LANGSTAGE_JUPYTER_SERVER_URL"):
+            assert env not in out, env
+        assert "agent_spec" in out
+
 
 class TestFindAvailablePort:
     """Tests for find_available_port function."""


### PR DESCRIPTION
From the daily dogfood routine (Fixes #34). Completes the #30 fix.

`--show-config` on the launcher still advertised three keys it doesn't honor:
- **`title`** — inherited from the web-app `HostConfig`, read nowhere in this stage.
- **`jupyter_token` / `jupyter_server_url`** — auto-generated/-detected at startup and overridden by the launcher. A user-set `LANGSTAGE_JUPYTER_TOKEN` is silently discarded (the launcher reads only the standard `JUPYTER_TOKEN`); the resolved `jupyter_server_url` is rebuilt from the auto-detected port.

All three are now dropped from the launcher's `--show-config` via `describe(omit_keys=[…])`, so it only advertises keys this stage actually honors — same wrong-mental-model class as #30's `host`/`port`.

(Left the token-honoring behavior change out deliberately: pinning via the standard `JUPYTER_TOKEN` already works, and honoring `LANGSTAGE_JUPYTER_TOKEN` is a separate security-adjacent decision.)

**Test:** `--show-config` with `LANGSTAGE_TITLE`/`JUPYTER_TOKEN`/`JUPYTER_SERVER_URL` set shows none of the three rows nor their env vars. 22 launcher tests pass.
