### PR TITLE
Re-root the agent filesystem on workspace change (#36)

### DIFF
--- a/langstage_jupyter/agent_wrapper.py
+++ b/langstage_jupyter/agent_wrapper.py
@@ -67,6 +67,12 @@ class AgentWrapper:
             self.agent_variable_name = agent_variable_name or config.AGENT_VARIABLE
 
         self._load_agent()
+        # The root the agent's backend was just built from (config.WORKSPACE_ROOT,
+        # else cwd "."). set_root_dir() compares against this so it only rebuilds
+        # when JupyterLab's live root actually differs. (gh #36)
+        self._applied_root = self._resolve_root(
+            str(config.WORKSPACE_ROOT) if config.WORKSPACE_ROOT else "."
+        )
 
     def _load_agent(self):
         """Load the agent via the shared host loader.
@@ -105,10 +111,16 @@ class AgentWrapper:
     def reload_agent(self):
         """Reload the agent module (useful for development)."""
         # Clear the module from sys.modules if it's there
+        # Clear the agent module (and its submodules) from sys.modules so the next
+        # load re-imports it. Match exactly or on a dotted-submodule prefix — a
+        # bare substring check also nuked unrelated modules (the module path
+        # 'langstage_jupyter.agent' is a substring of '...agent_wrapper'). (gh #36)
+        path = self.agent_module_path
         modules_to_remove = [
             mod_name for mod_name in sys.modules
-            if (self.agent_module_path in mod_name or
-                mod_name.startswith('custom_agent_'))
+            if (mod_name == path
+                or mod_name.startswith(path + ".")
+                or mod_name.startswith('custom_agent_'))
         ]
         for mod_name in modules_to_remove:
             del sys.modules[mod_name]
@@ -116,11 +128,20 @@ class AgentWrapper:
         # Reload
         self._load_agent()
 
+    @staticmethod
+    def _resolve_root(root: str) -> str:
+        """Normalize a root path for change comparison (absolute, expanded)."""
+        try:
+            return str(Path(root).expanduser().resolve())
+        except Exception:
+            return str(root)
+
     def set_root_dir(self, root_dir: str):
         """
-        Set the root directory on the agent's backend if it has one.
+        Re-point the agent's filesystem backend at JupyterLab's live root.
         Also publishes the workspace root as an environment variable for agents
-        to discover.
+        to discover. Called on every chat message; the agent is rebuilt only when
+        the resolved root actually changes.
 
         Args:
             root_dir: The root directory path (JupyterLab launch directory)
@@ -134,21 +155,43 @@ class AgentWrapper:
         os.environ['LANGSTAGE_WORKSPACE_ROOT'] = root_dir
         os.environ['DEEPAGENT_WORKSPACE_ROOT'] = root_dir
 
-        if self.agent and hasattr(self.agent, 'backend'):
+        # Re-root only on an actual change — set_root_dir runs on every message,
+        # and rebuilding each time would be wasteful and reset agent state.
+        resolved = self._resolve_root(root_dir)
+        if resolved == getattr(self, "_applied_root", None):
+            return
+        self._applied_root = resolved
+
+        # Fast path: an agent exposing a mutable filesystem backend is re-pointed
+        # in place. deepagents' CompiledStateGraph does NOT expose `.backend`, so
+        # this is for custom agents / future deepagents. (The old import path,
+        # `deepagents.tools.filesystem`, never existed — it's `deepagents.backends`.)
+        if self.agent is not None and hasattr(self.agent, 'backend'):
             try:
-                # Import FilesystemBackend dynamically
-                from deepagents.tools.filesystem import FilesystemBackend
-                # Update the backend's root_dir
+                from deepagents.backends import FilesystemBackend
                 self.agent.backend = FilesystemBackend(
                     root_dir=root_dir,
-                    virtual_mode=config.VIRTUAL_MODE
+                    virtual_mode=config.VIRTUAL_MODE,
                 )
                 print(f"Set agent backend root_dir to: {root_dir}")
+                return
             except ImportError:
-                # FilesystemBackend not available, skip
                 pass
             except Exception as e:
                 print(f"Warning: Could not set agent backend root_dir: {e}")
+
+        # General path (the bundled default and `create_deep_agent` agents): their
+        # FilesystemBackend is built from `config.WORKSPACE_ROOT` at import time, so
+        # refresh that resolved value and rebuild the agent — its backend then
+        # re-roots at the live directory. Previously this branch was dead (wrong
+        # import + a guard that's never true for a CompiledStateGraph), so the
+        # documented re-root never happened. (gh #36)
+        try:
+            config.WORKSPACE_ROOT = Path(resolved)
+            self.reload_agent()
+            print(f"Re-rooted agent filesystem to: {root_dir}")
+        except Exception as e:
+            print(f"Warning: Could not re-root agent to {root_dir}: {e}")
 
     def _append_context_to_message(self, message: str, context: Optional[Dict[str, Any]]) -> str:
         """

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/tests/test_reroot.py
+++ b/tests/test_reroot.py
@@ -1,0 +1,78 @@
+"""Workspace re-rooting actually re-roots the agent now (gh #36).
+
+`set_root_dir` ran on every chat message but its backend-rebuild branch was dead:
+it imported the non-existent `deepagents.tools.filesystem` behind a
+`hasattr(agent, 'backend')` guard that's never true for a CompiledStateGraph. So
+the documented "automatic workspace discovery" never happened. These tests cover
+the control flow: env is always published, the agent is rebuilt only when the
+resolved root changes, and an agent that *does* expose a mutable backend is
+re-pointed in place via the corrected import.
+"""
+
+from pathlib import Path
+
+from langstage_jupyter.agent_wrapper import AgentWrapper
+
+
+def _wrapper(applied_root, agent):
+    """Build a wrapper without loading a real agent (no model wiring needed)."""
+    w = AgentWrapper.__new__(AgentWrapper)
+    w.agent = agent
+    w.agent_module_path = "langstage_jupyter.agent"
+    w.agent_variable_name = None
+    w._applied_root = AgentWrapper._resolve_root(applied_root)
+    return w
+
+
+def test_publishes_env_vars(monkeypatch, tmp_path):
+    monkeypatch.delenv("LANGSTAGE_WORKSPACE_ROOT", raising=False)
+    monkeypatch.delenv("DEEPAGENT_WORKSPACE_ROOT", raising=False)
+    w = _wrapper(".", object())
+    w.reload_agent = lambda: None  # don't actually rebuild
+    w.set_root_dir(str(tmp_path))
+    import os
+    assert os.environ["LANGSTAGE_WORKSPACE_ROOT"] == str(tmp_path)
+    assert os.environ["DEEPAGENT_WORKSPACE_ROOT"] == str(tmp_path)  # legacy still set
+
+
+def test_noop_when_root_unchanged(tmp_path):
+    # An agent with no mutable backend, already rooted at tmp_path.
+    w = _wrapper(str(tmp_path), object())
+    calls = []
+    w.reload_agent = lambda: calls.append(1)
+    # Same resolved root (even via a non-normalized spelling) => no rebuild.
+    w.set_root_dir(str(tmp_path) + "/.")
+    assert calls == [], "must not rebuild when the root is unchanged"
+
+
+def test_rebuilds_when_root_changes(tmp_path):
+    w = _wrapper(str(tmp_path / "old"), object())  # no .backend
+    calls = []
+    w.reload_agent = lambda: calls.append(1)
+    new_root = tmp_path / "new"
+    new_root.mkdir()
+    w.set_root_dir(str(new_root))
+    assert calls == [1], "must rebuild once when the root changes"
+    assert w._applied_root == AgentWrapper._resolve_root(str(new_root))
+
+
+def test_in_place_backend_swap_uses_corrected_import(tmp_path):
+    # An agent that exposes a mutable `.backend` is re-pointed in place (no rebuild).
+    class FakeAgent:
+        backend = None
+
+    agent = FakeAgent()
+    w = _wrapper(str(tmp_path / "old"), agent)
+    calls = []
+    w.reload_agent = lambda: calls.append(1)
+    new_root = tmp_path / "new"
+    new_root.mkdir()
+    w.set_root_dir(str(new_root))
+    assert calls == [], "in-place swap should not trigger a rebuild"
+    # The corrected import (deepagents.backends) actually produced a backend.
+    from deepagents.backends import FilesystemBackend
+    assert isinstance(agent.backend, FilesystemBackend)
+
+
+def test_resolve_root_normalizes():
+    assert AgentWrapper._resolve_root(".") == str(Path(".").resolve())


### PR DESCRIPTION
## Problem

`AgentWrapper.set_root_dir()` runs on every chat message and is the mechanism behind the documented "Context Awareness / automatic workspace discovery." Its backend-rebuild branch could **never** execute:

1. **Wrong import** — `from deepagents.tools.filesystem import FilesystemBackend` (the module doesn't exist; it's `deepagents.backends`), swallowed by `except ImportError: pass`.
2. **Unreachable guard** — `hasattr(self.agent, 'backend')` is `False` for the `CompiledStateGraph` the bundled default and `create_deep_agent` agents return.

So when JupyterLab's root differs from the launch cwd, the agent kept reading/writing files at the wrong directory with no code path to correct it.

Fixes #36.

## Fix

- Correct the import to `deepagents.backends`.
- Keep the in-place `.backend` swap as a fast path for agents that expose a mutable backend (now with the right import).
- Make re-root actually work for the `CompiledStateGraph`: when the resolved root changes, refresh `config.WORKSPACE_ROOT` (read at agent-build time) and rebuild the agent so its `FilesystemBackend` re-roots — guarded to run only on an actual change, not on every message.
- Tighten `reload_agent`'s module matching (exact / dotted-submodule prefix) so it no longer also evicts unrelated modules via a bare substring check (the path `langstage_jupyter.agent` was a substring of `...agent_wrapper`).

## Tests

New `tests/test_reroot.py` (5 cases): env always published, no rebuild when root unchanged, rebuild once on change, in-place backend swap uses the corrected import, path normalization. 32 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
