### PR TITLE
Always rebuild the labextension cleanly so the wheel can't ship stale JS (#38)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "build": "yarn build:lib && yarn build:labextension:dev",
-    "build:prod": "yarn clean && yarn build:lib:prod && yarn build:labextension",
+    "build:prod": "yarn clean:all && yarn build:lib:prod && yarn build:labextension",
     "build:labextension": "jupyter labextension build .",
     "build:labextension:dev": "jupyter labextension build --development True .",
     "build:lib": "tsc --sourceMap",
@@ -37,7 +37,7 @@
     "clean": "yarn clean:lib",
     "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
     "clean:lintcache": "rimraf .eslintcache .stylelintcache",
-    "clean:labextension": "rimraf langstage_jupyter/labextension langstage_jupyter/*.tgz",
+    "clean:labextension": "rimraf langstage_jupyter/labextension",
     "clean:all": "yarn clean:lib && yarn clean:labextension && yarn clean:lintcache",
     "install:extension": "yarn build",
     "watch": "run-p watch:src watch:labextension",


### PR DESCRIPTION
## Problem

The published `langstage-jupyter` **0.5.10** wheel bundled a **0.5.9** labextension — `--version` / `pip` reported 0.5.10 but `jupyter labextension list` (and the served `share/jupyter/labextensions/.../package.json`) reported 0.5.9.

Root cause: `build:prod` ran `yarn clean`, which only cleans `lib/` (`clean:lib`), **not** the labextension. So the `langstage_jupyter/labextension/` bundle from the previous 0.5.9 build lingered, and the jupyter-builder hook's `skip-if-exists` (intentional — it's what lets no-Node installs work) re-packaged those stale assets. The version was bumped everywhere else, but the frontend bundle was never regenerated. Harmless for 0.5.10 (no `src/` change), but a **latent major**: the next real frontend change would silently ship the old JS.

Fixes #38.

## Fix

- `build:prod` now runs `clean:all` (lib + labextension + lintcache) before building, so every build regenerates a **fresh, correctly-versioned** labextension — nothing stale can linger for `skip-if-exists` to re-package. (`skip-if-exists` itself stays — the no-Node install path relies on it.)
- Fixed `clean:labextension`: its `langstage_jupyter/*.tgz` glob errored ("No matches found") under the yarn-berry shell when no tarball was present, aborting the clean chain. Dropped the incidental tarball glob.

Verified locally: `jlpm build:prod` now stamps the labextension `0.5.11` (matching the package).

Re-released as **0.5.11** with a freshly built labextension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
