### PR TITLE
Launcher: fail fast on a malformed --port instead of injecting a duplicate (#40)

### DIFF
--- a/langstage_jupyter/launcher.py
+++ b/langstage_jupyter/launcher.py
@@ -181,22 +181,25 @@ def main():
 
     # Check if user specified a port
     user_port = None
-    port_specified = False
     for i, arg in enumerate(args):
         if arg == '--port' and i + 1 < len(args):
-            try:
-                user_port = int(args[i + 1])
-                port_specified = True
-            except ValueError:
-                pass
-            break
+            raw = args[i + 1]
         elif arg.startswith('--port='):
-            try:
-                user_port = int(arg.split('=')[1])
-                port_specified = True
-            except ValueError:
-                pass
-            break
+            raw = arg.split('=', 1)[1]
+        else:
+            continue
+        # A --port was supplied — it MUST parse. If it doesn't (including an empty
+        # value, e.g. `--port=$PORT` with PORT unset), fail fast with a clear
+        # message. Previously we silently swallowed the parse error, auto-detected
+        # our OWN port, AND still passed the user's malformed --port token through
+        # to jupyter lab — so jupyter aborted with a confusing "port only accepts
+        # one value, got 2" naming a port the user never typed. (gh #40)
+        try:
+            user_port = int(raw)
+        except (ValueError, TypeError):
+            print(f"ERROR: invalid --port value: {raw!r}")
+            sys.exit(1)
+        break
 
     # Find available port
     if user_port:
@@ -241,8 +244,9 @@ def main():
     # wrong app and the chat sidebar silently never loads (gh #-dogfood).
     jupyter_args = [sys.executable, '-m', 'jupyterlab']
 
-    # Add port if not already specified by user
-    if not port_specified:
+    # Inject our auto-detected port only when the user didn't supply a valid one
+    # (a malformed --port already exited above), so we never pass two --port values.
+    if user_port is None:
         jupyter_args.extend(['--port', str(port)])
 
     # Add token

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -251,3 +251,36 @@ class TestLauncherIntegration:
 
         assert os.getenv('DEEPAGENT_JUPYTER_SERVER_URL') == f"http://localhost:{test_port}"
         assert os.getenv('DEEPAGENT_JUPYTER_TOKEN') == test_token
+
+
+class TestPortHandling:
+    """--port parse-failure must fail fast, not inject a duplicate port (gh #40)."""
+
+    def _run_main(self, argv, monkeypatch):
+        calls = {}
+
+        def fake_run(cmd, env=None):
+            calls["cmd"] = cmd
+
+        monkeypatch.setattr("langstage_jupyter.launcher.subprocess.run", fake_run)
+        monkeypatch.setattr("sys.argv", ["langstage-jupyter"] + argv)
+        main()
+        return calls
+
+    @pytest.mark.parametrize("bad", ["--port=", "--port=notaport"])
+    def test_malformed_port_exits_cleanly(self, monkeypatch, capsys, bad):
+        monkeypatch.setattr("sys.argv", ["langstage-jupyter", bad, "--no-browser"])
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 1
+        assert "invalid --port value" in capsys.readouterr().out
+
+    def test_valid_port_is_not_duplicated(self, monkeypatch):
+        calls = self._run_main(["--port=19191", "--no-browser"], monkeypatch)
+        # the launcher must NOT inject its own --port on top of the user's.
+        assert calls["cmd"].count("--port") == 0  # space-form not added...
+        assert "--port=19191" in calls["cmd"]  # ...the user's token passes through once
+
+    def test_no_port_auto_injects_one(self, monkeypatch):
+        calls = self._run_main(["--no-browser"], monkeypatch)
+        assert calls["cmd"].count("--port") == 1  # exactly one, auto-detected


### PR DESCRIPTION
## Problem

Given a `--port` value that isn't a valid integer — including an **empty** value from an unset shell var (`--port=$PORT`) — the launcher silently swallowed the parse error, **auto-detected its own port and injected `--port <n>`**, *and* still passed the user's malformed `--port=` token through to `jupyter lab`. JupyterLab then saw two `--port` values and aborted:

```
Auto-detected available port: 8888
ServerApp.port=['8888', ''], port only accepts one value, got 2: ['8888', '']
```

— naming a port (`8888`) the user never typed, with no way to tell the second value came from the launcher itself.

Fixes #40.

## Fix

- A supplied `--port` **must parse**; if it doesn't, print `ERROR: invalid --port value: '<raw>'` and exit 1 (same shape as the existing `--demo`/`-a` conflict).
- Inject the auto-detected port **only** when the user supplied no valid one, so we never emit two `--port` values.

A correctly-formatted `--port=19191` is unaffected and passes through once.

## Tests

`tests/test_launcher.py`: malformed/empty `--port` exits 1 with "invalid --port value"; a valid `--port` isn't duplicated; no `--port` auto-injects exactly one. 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
