### PR TITLE
feat: experimental in-process AG-UI streaming path (ADR 0002, jupyter)

### DIFF
--- a/langstage_jupyter/agent_wrapper.py
+++ b/langstage_jupyter/agent_wrapper.py
@@ -15,8 +15,10 @@ from dotenv import find_dotenv, load_dotenv
 # (gh #32)
 load_dotenv(find_dotenv(usecwd=True))
 
-# Import configuration
+# Import configuration. Also aliased as `config_module` for use inside methods
+# whose `config` parameter shadows the module name (e.g. execute()).
 from . import config
+from . import config as config_module
 from langgraph_stream_parser import (
     stream_graph_updates,
     prepare_agent_input,
@@ -84,6 +86,8 @@ class AgentWrapper:
         was requested, falls back from ``agent`` to ``graph`` — preserving the
         extension's historical default-name behavior.
         """
+        # Invalidate any cached AG-UI wrapper so it rebuilds around the fresh graph.
+        self._agui_agent = None
         var = self.agent_variable_name or "agent"
         try:
             self.agent = load_agent_spec(f"{self.agent_module_path}:{var}")
@@ -289,6 +293,39 @@ class AgentWrapper:
         if thread_id:
             agent_config["configurable"] = agent_config.get("configurable", {})
             agent_config["configurable"]["thread_id"] = thread_id
+
+        # Experimental (ADR 0002): route streaming through the in-process AG-UI
+        # adapter instead of the built-in event parser, yielding the SAME chunk
+        # shape the frontend already consumes. Opt-in via LANGSTAGE_JUPYTER_AGUI.
+        if config_module.AGUI:
+            from .agui_stream import build_session_agent, stream_updates_sync
+
+            try:
+                if self._agui_agent is None:
+                    self._agui_agent = build_session_agent(self.agent)
+            except RuntimeError as e:
+                yield {"error": str(e), "status": "error"}
+                return
+
+            tid = "jupyter"
+            if isinstance(agent_config, dict):
+                tid = agent_config.get("configurable", {}).get("thread_id", "jupyter")
+
+            if message is not None:
+                agui_msg = self._append_context_to_message(message, context)
+                resume = None
+            elif decisions is not None:
+                agui_msg, resume = "", {"decisions": decisions}
+            else:
+                yield {"error": "Must provide either 'message' or 'decisions'", "status": "error"}
+                return
+
+            try:
+                for chunk in stream_updates_sync(self._agui_agent, agui_msg, tid, resume=resume):
+                    yield chunk
+            except Exception as e:
+                yield {"error": f"Error executing agent: {str(e)}", "status": "error"}
+            return
 
         try:
             # Handle message input

--- a/langstage_jupyter/agui_stream.py
+++ b/langstage_jupyter/agui_stream.py
@@ -1,0 +1,127 @@
+"""Experimental in-process AG-UI streaming path for the Jupyter sidebar.
+
+ADR 0002 (cli-first pattern, now jupyter): drive the agent through the official
+``ag-ui-langgraph`` adapter in-process (no web server) and map AG-UI events onto
+the same chunk dicts the frontend already consumes from ``stream_graph_updates``
+— so the labextension is unchanged. Text, tool calls/results, and interrupts
+(display + resume via ``forwarded_props.command.resume``) are all supported.
+
+NOTE: this mapping is intentionally identical to ``langstage_cli.agui_stream``.
+When a third surface (vscode/web) adopts it, hoist the shared mapping into the
+core's ``langgraph_stream_parser.agui`` module and drop the copies.
+
+Requires the ``agui`` extra::
+
+    pip install "langstage-jupyter[agui]"
+"""
+import json
+import uuid
+from typing import Any, AsyncIterator, Dict
+
+_IMPORT_HINT = 'the AG-UI path needs the agui extra: pip install "langstage-jupyter[agui]"'
+
+
+def ensure_agui_available() -> None:
+    """Raise a clean, actionable error if the AG-UI adapter isn't installed."""
+    try:
+        import ag_ui_langgraph  # noqa: F401
+        from langgraph_stream_parser.agui import build_agent  # noqa: F401
+    except ImportError as e:  # pragma: no cover - exercised only without the extra
+        raise RuntimeError(_IMPORT_HINT) from e
+
+
+def build_session_agent(graph: Any, *, name: str = "langstage-jupyter") -> Any:
+    """Wrap a compiled graph once (checkpointer attached by the core bridge) so
+    multi-turn memory persists; thread_id is passed per run for per-chat state."""
+    ensure_agui_available()
+    from langgraph_stream_parser.agui import build_agent
+
+    return build_agent(graph, name=name)
+
+
+async def agui_stream_updates(
+    agent: Any, message: str, thread_id: str, resume: Any = None
+) -> AsyncIterator[Dict[str, Any]]:
+    """Drive ``agent.run()`` in-process and yield ``stream_graph_updates``-shaped chunks.
+
+    Maps: TextMessageContent -> text; ToolCall{Start,Args,End} -> tool_calls;
+    ToolCallResult -> tool_result; CustomEvent(on_interrupt) -> interrupt;
+    RunError -> error; one-shot MessagesSnapshot -> text. Ends with ``complete``.
+
+    ``resume`` (a decision answering an interrupt) is delivered as
+    ``forwarded_props.command.resume`` -> LangGraph ``Command(resume=...)``.
+    """
+    from ag_ui.core.types import RunAgentInput, UserMessage
+
+    forwarded_props: Dict[str, Any] = {}
+    if resume is not None:
+        forwarded_props = {"command": {"resume": resume}}
+
+    run_input = RunAgentInput(
+        thread_id=thread_id,
+        run_id=str(uuid.uuid4()),
+        state={},
+        messages=[UserMessage(id=str(uuid.uuid4()), role="user", content=message)],
+        tools=[],
+        context=[],
+        forwarded_props=forwarded_props,
+    )
+
+    streamed_text = False
+    tool_buf: Dict[str, Dict[str, str]] = {}
+
+    async for ev in agent.run(run_input):
+        t = type(ev).__name__
+        if t == "TextMessageContentEvent":
+            streamed_text = True
+            yield {"status": "streaming", "chunk": ev.delta, "node": "agent"}
+        elif t == "ToolCallStartEvent":
+            tool_buf[ev.tool_call_id] = {"name": ev.tool_call_name, "args": ""}
+        elif t == "ToolCallArgsEvent":
+            tool_buf.setdefault(ev.tool_call_id, {"name": "tool", "args": ""})["args"] += ev.delta
+        elif t == "ToolCallEndEvent":
+            tc = tool_buf.pop(ev.tool_call_id, {"name": "tool", "args": ""})
+            try:
+                args = json.loads(tc["args"]) if tc["args"] else {}
+            except json.JSONDecodeError:
+                args = {"_raw": tc["args"]}
+            yield {"status": "streaming", "tool_calls": [{"name": tc["name"], "args": args}]}
+        elif t == "ToolCallResultEvent":
+            yield {"status": "streaming", "tool_result": getattr(ev, "content", "")}
+        elif t == "CustomEvent" and getattr(ev, "name", None) == "on_interrupt":
+            payload = getattr(ev, "value", None)
+            if isinstance(payload, str):
+                try:
+                    payload = json.loads(payload)
+                except json.JSONDecodeError:
+                    payload = {"action_requests": []}
+            yield {"status": "interrupt", "interrupt": payload or {"action_requests": []}}
+        elif t == "MessagesSnapshotEvent" and not streamed_text:
+            for m in ev.messages:
+                if getattr(m, "role", None) == "assistant" and getattr(m, "content", None):
+                    yield {"status": "streaming", "chunk": m.content, "node": "agent"}
+        elif t == "RunErrorEvent":
+            yield {"status": "error", "error": getattr(ev, "message", "unknown error")}
+
+    yield {"status": "complete"}
+
+
+def stream_updates_sync(agent: Any, message: str, thread_id: str, resume: Any = None):
+    """Sync bridge: pump the async AG-UI generator one chunk at a time.
+
+    ``AgentWrapper.execute`` is a sync generator that the server handler runs in a
+    worker thread (no running event loop), so a fresh loop here is safe and keeps
+    streaming lazy (yield per chunk, not collect-then-yield).
+    """
+    import asyncio
+
+    loop = asyncio.new_event_loop()
+    try:
+        agen = agui_stream_updates(agent, message, thread_id, resume=resume)
+        while True:
+            try:
+                yield loop.run_until_complete(agen.__anext__())
+            except StopAsyncIteration:
+                break
+    finally:
+        loop.close()

--- a/langstage_jupyter/config.py
+++ b/langstage_jupyter/config.py
@@ -99,3 +99,8 @@ VIRTUAL_MODE = _cfg.virtual_mode
 # jupyter.execute_timeout in langstage.toml both apply (the old get_config()
 # read only DEEPAGENT_EXECUTE_TIMEOUT). agent.py reads this constant.
 EXECUTE_TIMEOUT = _cfg.execute_timeout
+# [experimental] Route streaming through the in-process AG-UI adapter instead of
+# the built-in event parser (ADR 0002, cli-first pattern). Opt-in via
+# LANGSTAGE_JUPYTER_AGUI=1 (or legacy DEEPAGENT_JUPYTER_AGUI). Requires the agui
+# extra: pip install "langstage-jupyter[agui]".
+AGUI = get_config("JUPYTER_AGUI", False, _to_bool)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "pytest-asyncio>=0.21.0",
+    # The experimental AG-UI path (ADR 0002); pulled into dev so CI exercises
+    # tests/test_agui_stream.py instead of skipping it.
+    "ag-ui-langgraph>=0.0.41",
+    "fastapi",
 ]
 agui = ["langgraph-stream-parser[agui]>=0.6.11,<0.7"]
 

--- a/tests/test_agui_stream.py
+++ b/tests/test_agui_stream.py
@@ -1,0 +1,81 @@
+"""Tests for the experimental in-process AG-UI streaming path (ADR 0002).
+
+Skipped unless the agui extra is installed. The dev extra pulls it so CI runs these.
+"""
+import asyncio
+
+import pytest
+
+pytest.importorskip("ag_ui_langgraph")
+pytest.importorskip("fastapi")
+
+from langchain_core.messages import AIMessage  # noqa: E402
+from langgraph.checkpoint.memory import InMemorySaver  # noqa: E402
+from langgraph.graph import END, START, MessagesState, StateGraph  # noqa: E402
+from langgraph.types import interrupt  # noqa: E402
+from langgraph_stream_parser import load_agent_spec  # noqa: E402
+
+from langstage_jupyter import agent_wrapper as aw  # noqa: E402
+from langstage_jupyter.agui_stream import (  # noqa: E402
+    agui_stream_updates,
+    build_session_agent,
+    stream_updates_sync,
+)
+
+
+def _collect(agent, msg, resume=None):
+    async def go():
+        return [c async for c in agui_stream_updates(agent, msg, "t", resume=resume)]
+
+    return asyncio.run(go())
+
+
+def test_text_parity_on_demo_stub():
+    agent = build_session_agent(load_agent_spec("langgraph_stream_parser.demo.stub:graph"))
+    chunks = _collect(agent, "hello jupyter agui")
+    text = "".join(c["chunk"] for c in chunks if "chunk" in c)
+    assert "hello jupyter agui" in text
+    assert chunks[-1]["status"] == "complete"
+
+
+def test_sync_bridge_yields_chunks():
+    """stream_updates_sync pumps the async generator in a plain (sync) context."""
+    agent = build_session_agent(load_agent_spec("langgraph_stream_parser.demo.stub:graph"))
+    chunks = list(stream_updates_sync(agent, "sync bridge", "t"))
+    # tokens stream across chunks, so join before checking (like the other tests)
+    assert "sync bridge" in "".join(c.get("chunk", "") for c in chunks)
+    assert chunks[-1]["status"] == "complete"
+
+
+def _interrupt_graph():
+    def gate(state):
+        d = interrupt({"action_requests": [{"tool": "approve", "args": {}}]})
+        return {"messages": [AIMessage(content=f"resolved: {d}")]}
+
+    b = StateGraph(MessagesState)
+    b.add_node("gate", gate)
+    b.add_edge(START, "gate")
+    b.add_edge("gate", END)
+    return b.compile(checkpointer=InMemorySaver())
+
+
+def test_interrupt_display_and_resume():
+    agent = build_session_agent(_interrupt_graph())
+    c1 = _collect(agent, "go")
+    assert any(c.get("status") == "interrupt" for c in c1), c1
+    c2 = _collect(agent, "", resume={"decisions": [{"type": "accept"}]})
+    assert not any(c.get("status") == "interrupt" for c in c2), c2
+    assert "resolved:" in "".join(c["chunk"] for c in c2 if "chunk" in c)
+
+
+def test_wrapper_routes_through_agui(monkeypatch):
+    """AgentWrapper.execute() streams via AG-UI when the toggle is on."""
+    monkeypatch.setattr(aw.config_module, "AGUI", True)
+    w = aw.AgentWrapper.__new__(aw.AgentWrapper)  # bypass __init__ (no agent to load)
+    w.agent = load_agent_spec("langgraph_stream_parser.demo.stub:graph")
+    w._agui_agent = None
+
+    chunks = list(w.execute(message="via wrapper", thread_id="w1"))
+    text = "".join(c["chunk"] for c in chunks if "chunk" in c)
+    assert "via wrapper" in text
+    assert chunks[-1]["status"] == "complete"


### PR DESCRIPTION
## What

Second surface of the **ADR 0002** migration (after the cli): an **experimental, opt-in** in-process AG-UI streaming path for the Jupyter sidebar. Enable with `LANGSTAGE_JUPYTER_AGUI=1`.

`AgentWrapper.execute()` streams through the official `ag-ui-langgraph` adapter **in-process** (no web server) and maps AG-UI events onto the **same chunk shape the frontend already consumes** from `stream_graph_updates` — so the **labextension is unchanged**.

## How

- **`langstage_jupyter/agui_stream.py`** (new):
  - `build_session_agent()` — wraps the graph once (checkpointer attached by the core bridge; `thread_id` passed per run for per-chat state).
  - `agui_stream_updates()` — maps text, tool calls/results, and interrupts (display **and** resume via `forwarded_props.command.resume`) to the chunk dicts.
  - `stream_updates_sync()` — pumps the async generator one chunk at a time inside `execute()`'s worker thread with a fresh event loop. Safe because the server handler already runs `execute()` in a thread pool (no running loop there), and it keeps streaming lazy.
- **`config.AGUI`** toggle (`LANGSTAGE_JUPYTER_AGUI` / legacy `DEEPAGENT_JUPYTER_AGUI`).
- **`AgentWrapper.execute()`** routes through AG-UI when the toggle is on, for both messages and interrupt resumption (`decisions → forwarded_props.command.resume`); the cached AG-UI agent is invalidated on `reload_agent()`.

## Tests

`tests/test_agui_stream.py`: text parity on the demo stub, the sync bridge, interrupt **display + resume**, and the wrapper routing end-to-end. Added `ag-ui-langgraph` + `fastapi` to the **dev extra** so CI runs them. Full suite: **95 passed**, no regressions.

## Notes

- Default (non-`AGUI`) path is **untouched**; requires the `[agui]` extra.
- The mapping is intentionally identical to `langstage_cli.agui_stream` — flagged in-code: when a third surface (vscode/web) adopts it, hoist the shared mapping into the core's `langgraph_stream_parser.agui` and drop the copies.
- Python-only change; no frontend/labextension change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
