### PR TITLE
refactor(agui): delegate chunk mapping to core iter_chunk_frames (ADR 0002 dedupe)

### DIFF
--- a/langstage_jupyter/agui_stream.py
+++ b/langstage_jupyter/agui_stream.py
@@ -6,16 +6,14 @@ the same chunk dicts the frontend already consumes from ``stream_graph_updates``
 — so the labextension is unchanged. Text, tool calls/results, and interrupts
 (display + resume via ``forwarded_props.command.resume``) are all supported.
 
-NOTE: this mapping is intentionally identical to ``langstage_cli.agui_stream``.
-When a third surface (vscode/web) adopts it, hoist the shared mapping into the
-core's ``langgraph_stream_parser.agui`` module and drop the copies.
+NOTE: the AG-UI->chunk-dict mapping now lives in the core
+(``langgraph_stream_parser.agui.iter_chunk_frames``, 0.6.17) and is shared with
+langstage-cli; this module keeps only the thin session/pump wrappers.
 
 Requires the ``agui`` extra::
 
     pip install "langstage-jupyter[agui]"
 """
-import json
-import uuid
 from typing import Any, AsyncIterator, Dict
 
 _IMPORT_HINT = 'the AG-UI path needs the agui extra: pip install "langstage-jupyter[agui]"'
@@ -50,60 +48,14 @@ async def agui_stream_updates(
 
     ``resume`` (a decision answering an interrupt) is delivered as
     ``forwarded_props.command.resume`` -> LangGraph ``Command(resume=...)``.
+
+    The mapping itself lives in the core (``agui.iter_chunk_frames``, 0.6.17) —
+    shared with langstage-cli — so a rendering fix lands once.
     """
-    from ag_ui.core.types import RunAgentInput, UserMessage
+    from langgraph_stream_parser.agui import iter_chunk_frames
 
-    forwarded_props: Dict[str, Any] = {}
-    if resume is not None:
-        forwarded_props = {"command": {"resume": resume}}
-
-    run_input = RunAgentInput(
-        thread_id=thread_id,
-        run_id=str(uuid.uuid4()),
-        state={},
-        messages=[UserMessage(id=str(uuid.uuid4()), role="user", content=message)],
-        tools=[],
-        context=[],
-        forwarded_props=forwarded_props,
-    )
-
-    streamed_text = False
-    tool_buf: Dict[str, Dict[str, str]] = {}
-
-    async for ev in agent.run(run_input):
-        t = type(ev).__name__
-        if t == "TextMessageContentEvent":
-            streamed_text = True
-            yield {"status": "streaming", "chunk": ev.delta, "node": "agent"}
-        elif t == "ToolCallStartEvent":
-            tool_buf[ev.tool_call_id] = {"name": ev.tool_call_name, "args": ""}
-        elif t == "ToolCallArgsEvent":
-            tool_buf.setdefault(ev.tool_call_id, {"name": "tool", "args": ""})["args"] += ev.delta
-        elif t == "ToolCallEndEvent":
-            tc = tool_buf.pop(ev.tool_call_id, {"name": "tool", "args": ""})
-            try:
-                args = json.loads(tc["args"]) if tc["args"] else {}
-            except json.JSONDecodeError:
-                args = {"_raw": tc["args"]}
-            yield {"status": "streaming", "tool_calls": [{"name": tc["name"], "args": args}]}
-        elif t == "ToolCallResultEvent":
-            yield {"status": "streaming", "tool_result": getattr(ev, "content", "")}
-        elif t == "CustomEvent" and getattr(ev, "name", None) == "on_interrupt":
-            payload = getattr(ev, "value", None)
-            if isinstance(payload, str):
-                try:
-                    payload = json.loads(payload)
-                except json.JSONDecodeError:
-                    payload = {"action_requests": []}
-            yield {"status": "interrupt", "interrupt": payload or {"action_requests": []}}
-        elif t == "MessagesSnapshotEvent" and not streamed_text:
-            for m in ev.messages:
-                if getattr(m, "role", None) == "assistant" and getattr(m, "content", None):
-                    yield {"status": "streaming", "chunk": m.content, "node": "agent"}
-        elif t == "RunErrorEvent":
-            yield {"status": "error", "error": getattr(ev, "message", "unknown error")}
-
-    yield {"status": "complete"}
+    async for frame in iter_chunk_frames(agent, message, thread_id, resume=resume):
+        yield frame
 
 
 def stream_updates_sync(agent: Any, message: str, thread_id: str, resume: Any = None):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     # >=0.6.11 carries describe(omit_keys=...) (so --show-config can hide the
     # inherited host/port rows this stage doesn't honor); also the agent-name
     # slugify fix (gh #23) and BOM-safe TOML.
-    "langgraph-stream-parser>=0.6.11,<0.7",
+    "langgraph-stream-parser>=0.6.17,<0.7",
     "python-dotenv>=0.19.0",
     "deepagents>=0.1.0",
     # Direct top-level imports in langstage_jupyter/agent.py. Previously only
@@ -64,7 +64,7 @@ dev = [
     "ag-ui-langgraph>=0.0.41",
     "fastapi",
 ]
-agui = ["langgraph-stream-parser[agui]>=0.6.11,<0.7"]
+agui = ["langgraph-stream-parser[agui]>=0.6.17,<0.7"]
 
 [tool.hatch.version]
 source = "nodejs"


### PR DESCRIPTION
`agui_stream_updates` now delegates to the core's `agui.iter_chunk_frames` (0.6.17) instead of its own copy — the byte-identical twin of langstage-cli's. **Behavior unchanged** (4 agui tests pass). Core floor → `>=0.6.17`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)