### PR TITLE
Honor an explicitly pinned workspace root (gh #45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.1 - 2026-07-02
+
+### Fixed
+- **An explicit workspace root was silently discarded (gh #45).** `set_root_dir`
+  runs on every chat message and re-rooted the agent (and overwrote
+  `LANGSTAGE_WORKSPACE_ROOT`) to JupyterLab's launch dir — clobbering a workspace
+  the operator had pinned via `LANGSTAGE_WORKSPACE_ROOT` / legacy
+  `DEEPAGENT_WORKSPACE_ROOT` or `workspace.root` in `langstage.toml` (advertised ≠
+  honored). A pinned root is now honored: the auto-follow only applies when no
+  workspace is pinned. The pinned value is captured at wrapper init (before
+  `set_root_dir` can mutate it).
+
 ## 0.6.0 - 2026-07-02
 
 ### Changed

--- a/langstage_jupyter/agent_wrapper.py
+++ b/langstage_jupyter/agent_wrapper.py
@@ -63,6 +63,14 @@ class AgentWrapper:
             self.agent_variable_name = agent_variable_name or config.AGENT_VARIABLE
 
         self._load_agent()
+        # Whether the operator pinned an explicit workspace root — via
+        # LANGSTAGE_WORKSPACE_ROOT / legacy DEEPAGENT_WORKSPACE_ROOT, or
+        # workspace.root in langstage.toml. config.WORKSPACE_ROOT is None only when
+        # the source is "default" (unset). If pinned, set_root_dir() must honor it
+        # rather than silently re-rooting to JupyterLab's launch dir. Captured here
+        # because set_root_dir() itself mutates config.WORKSPACE_ROOT. (gh #45)
+        self._workspace_pinned = config.WORKSPACE_ROOT is not None
+        self._pinned_root = str(config.WORKSPACE_ROOT) if config.WORKSPACE_ROOT else None
         # The root the agent's backend was just built from (config.WORKSPACE_ROOT,
         # else cwd "."). set_root_dir() compares against this so it only rebuilds
         # when JupyterLab's live root actually differs. (gh #36)
@@ -144,6 +152,19 @@ class AgentWrapper:
         Args:
             root_dir: The root directory path (JupyterLab launch directory)
         """
+        # Honor an explicitly pinned workspace root (LANGSTAGE_WORKSPACE_ROOT /
+        # workspace.root in langstage.toml) — don't silently re-root to JupyterLab's
+        # launch dir. The auto-follow below is only for the default (unpinned) case,
+        # where following the live JupyterLab dir is the convenience. Publish the
+        # pinned root for agents that read it at runtime (setdefault so an explicit
+        # env value the operator already set is never clobbered). (gh #45)
+        if getattr(self, "_workspace_pinned", False):
+            pinned = getattr(self, "_pinned_root", None)
+            if pinned:
+                os.environ.setdefault("LANGSTAGE_WORKSPACE_ROOT", pinned)
+                os.environ.setdefault("DEEPAGENT_WORKSPACE_ROOT", pinned)
+            return
+
         # Publish BOTH the canonical and the legacy env name. The README's own
         # custom-agent example reads canonical `LANGSTAGE_WORKSPACE_ROOT`, so a
         # user following the docs verbatim would otherwise see "." instead of

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,25 @@ from pathlib import Path
 from unittest.mock import Mock
 
 
+@pytest.fixture(autouse=True)
+def _restore_workspace_root():
+    """Snapshot + restore the module-level ``config.WORKSPACE_ROOT`` around each test.
+
+    ``set_root_dir()`` mutates this global (gh #36) to re-root the agent. In a real
+    session that's a fresh process, but under pytest the module persists, so the
+    mutation would leak into the next test — and trip the gh #45 pinned-workspace
+    detection, which reads ``config.WORKSPACE_ROOT`` at wrapper init. Restoring it
+    per test keeps isolation.
+    """
+    import langstage_jupyter.config as _cfg
+
+    saved = _cfg.WORKSPACE_ROOT
+    try:
+        yield
+    finally:
+        _cfg.WORKSPACE_ROOT = saved
+
+
 @pytest.fixture
 def clean_env(monkeypatch):
     """

--- a/tests/test_reroot.py
+++ b/tests/test_reroot.py
@@ -74,5 +74,28 @@ def test_in_place_backend_swap_uses_corrected_import(tmp_path):
     assert isinstance(agent.backend, FilesystemBackend)
 
 
+def test_pinned_workspace_root_is_honored(monkeypatch, tmp_path):
+    # gh #45: an explicitly pinned workspace root (LANGSTAGE_WORKSPACE_ROOT or
+    # workspace.root in langstage.toml) must win — set_root_dir() must NOT silently
+    # re-root to JupyterLab's launch dir, and must not overwrite the pinned env.
+    pinned = str(tmp_path / "pinned")
+    monkeypatch.setenv("LANGSTAGE_WORKSPACE_ROOT", pinned)
+    monkeypatch.delenv("DEEPAGENT_WORKSPACE_ROOT", raising=False)
+
+    w = _wrapper(pinned, object())
+    w._workspace_pinned = True
+    w._pinned_root = pinned
+    calls = []
+    w.reload_agent = lambda: calls.append(1)
+
+    w.set_root_dir(str(tmp_path / "jupyter_launch_dir"))  # the live JupyterLab dir
+
+    import os
+    assert calls == [], "must not rebuild/re-root when a workspace root is pinned"
+    # The pinned root is preserved, NOT clobbered by the JupyterLab launch dir.
+    assert os.environ["LANGSTAGE_WORKSPACE_ROOT"] == pinned
+    assert w._applied_root == AgentWrapper._resolve_root(pinned)
+
+
 def test_resolve_root_normalizes():
     assert AgentWrapper._resolve_root(".") == str(Path(".").resolve())


### PR DESCRIPTION
Closes #45.

`set_root_dir` runs on every chat message and re-rooted the agent (and overwrote `LANGSTAGE_WORKSPACE_ROOT`) to JupyterLab's launch dir — silently clobbering a workspace the operator pinned via `LANGSTAGE_WORKSPACE_ROOT` / legacy `DEEPAGENT_WORKSPACE_ROOT` or `workspace.root` in `langstage.toml` (advertised ≠ honored).

Now a pinned root is honored — the auto-follow-JupyterLab-dir behavior only applies when nothing is pinned. The pinned state is captured at wrapper init (before `set_root_dir` can mutate the module-level `config.WORKSPACE_ROOT`). Added an autouse conftest fixture that restores that global per test (it's mutated by `set_root_dir` — harmless in a real per-session process, but leaked across tests). Regression test added; 96 pass.

Bump `0.6.0 → 0.6.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)