### PR TITLE
Rebuild labextension so the wheel version matches (gh #48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.2 - 2026-07-03
+
+### Fixed
+- **The 0.6.1 wheel bundled a stale labextension reporting v0.6.0 (gh #48).** 0.6.1
+  was a Python-only fix, and the build hook skips the labextension rebuild when a
+  built copy already exists — so the published wheel shipped the previous release's
+  JS bundle (correct behavior, wrong version label). Rebuilt cleanly so the bundled
+  labextension version matches the package (verified `0.6.2` in the wheel before
+  publish). No functional change to the extension.
+
 ## 0.6.1 - 2026-07-02
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
Closes #48.

0.6.1 was a Python-only fix, and the `hatch-jupyter-builder` hook **skips the labextension rebuild when a built copy already exists** — so the published 0.6.1 wheel shipped the previous release's JS bundle, which `jupyter labextension list` reported as **v0.6.0**. Correct code, wrong version label.

Fix: bump to 0.6.2 and clean-rebuild the labextension. Verified the rebuilt `langstage_jupyter/labextension/package.json` reports `0.6.2`; the publish does a clean rebuild + checks the bundled version before uploading. No functional change to the extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)