### PR TITLE
ci: assert built labextension version == wheel version (gh #38/#48)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,3 +100,26 @@ jobs:
           /tmp/mi/bin/pip install .
           /tmp/mi/bin/python -c "import langstage_jupyter; print('ok')"
           /tmp/mi/bin/python -c "import langstage_jupyter.config, langstage_jupyter.agent_wrapper, langstage_jupyter.handlers, langstage_jupyter.agent, langstage_jupyter.launcher; print('ok')"
+
+  # gh #38/#48 guard: the built wheel must bundle a labextension whose version
+  # matches the wheel. The drift (skip-if-exists reusing a stale JS bundle) shipped
+  # a mislabelled labextension twice. This builds a release wheel and asserts parity;
+  # scripts/check_labext_version.py is the same check the release runs before publish.
+  labext-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Build a release wheel (fresh labextension)
+        run: |
+          python -m pip install --upgrade pip build "jupyterlab>=4.0,<5"
+          jlpm install --no-immutable
+          jlpm build:prod
+          python -m build --wheel
+      - name: Assert bundled labextension version == wheel version
+        run: python scripts/check_labext_version.py

--- a/scripts/check_labext_version.py
+++ b/scripts/check_labext_version.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+"""Assert a built wheel's bundled labextension version == the wheel version.
+
+Why this exists (gh #38, gh #48 — the *same* drift, twice): the
+`hatch-jupyter-builder` hook has `skip-if-exists`, so if a previously-built
+`langstage_jupyter/labextension/` is present, the npm rebuild is SKIPPED and the
+wheel ships the *previous* release's JS bundle — `jupyter labextension list`
+then reports the old version while `pip`/`--version` report the new one. It
+passed CI both times (a clean checkout has no stale artifact to skip over), so
+the only place it bites is a local release build. This check is the release-time
+gate: run it against `dist/*.whl` *before* `uv publish`.
+
+Usage:
+    python scripts/check_labext_version.py [wheel ...]   # defaults to dist/*.whl
+
+Exit code 0 = all wheels match; 1 = a mismatch (or a wheel with no bundled
+labextension); 2 = nothing to check.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+# The bundled labextension manifest, wherever hatchling's shared-data mapping put
+# it inside the wheel (…/share/jupyter/labextensions/langstage-jupyter/package.json).
+_LABEXT_MANIFEST = "labextensions/langstage-jupyter/package.json"
+
+
+def _wheel_version(wheel_path: str) -> str | None:
+    # dist/langstage_jupyter-0.6.2-py3-none-any.whl -> 0.6.2
+    m = re.match(r"[^-]+-([^-]+)-", Path(wheel_path).name)
+    return m.group(1) if m else None
+
+
+def main(argv: list[str]) -> int:
+    wheels = argv or sorted(glob.glob("dist/*.whl"))
+    if not wheels:
+        print("check_labext_version: no wheel found (build one first)", file=sys.stderr)
+        return 2
+
+    failures = 0
+    for wheel in wheels:
+        wheel_v = _wheel_version(wheel)
+        with zipfile.ZipFile(wheel) as zf:
+            manifests = [n for n in zf.namelist() if n.endswith(_LABEXT_MANIFEST)]
+            if not manifests:
+                print(f"MISMATCH {wheel}: no bundled labextension package.json")
+                failures += 1
+                continue
+            labext_v = json.loads(zf.read(manifests[0]))["version"]
+        if labext_v != wheel_v:
+            print(
+                f"MISMATCH {wheel}: wheel version {wheel_v!r} != bundled labextension "
+                f"version {labext_v!r} -- rebuild the labextension cleanly "
+                f"(rm -rf langstage_jupyter/labextension && jlpm build:prod) before publishing."
+            )
+            failures += 1
+        else:
+            print(f"ok {Path(wheel).name}: wheel == labextension == {wheel_v}")
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
The labextension-vs-wheel version drift shipped **twice** (#38: 0.5.10 shipped a 0.5.9 labextension; #48: 0.6.1 shipped 0.6.0) — the `hatch-jupyter-builder` `skip-if-exists` hook reuses a previously-built `langstage_jupyter/labextension/`, so a release built over a stale artifact bundles the old JS. Both were fixed by a manual "verified before publish"; nothing enforced it.

### What
- **`scripts/check_labext_version.py`** — inspects `dist/*.whl`, extracts the bundled `.../labextensions/langstage-jupyter/package.json` version, and asserts it equals the wheel version. Exit 1 on mismatch. This is the **release-time gate** — run it before `uv publish`.
- **`labext-version` CI job** — builds a release wheel and runs the script.

### Honest limitation
A clean CI checkout has no stale labextension to skip over, so CI always builds fresh and the drift can't be *reproduced* there — the job codifies the invariant, but the script run **at release time** (where a local stale artifact exists) is the real defense. Verified both directions locally: matches → exit 0; a wheel labelled `9.9.9` bundling a `0.6.2` labext → `MISMATCH`, exit 1.

Part of the dogfooding-synthesis guardrails (ADR 0004 in langstage-core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)