### PR TITLE
feat: langstage-jupyter --verify preflights the agent (ADR 0004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.6.3 - 2026-07-03
+
+### Added
+- **`langstage-jupyter --verify`: preflight the agent with one real turn (ADR 0004).**
+  The extension previously had no real readiness check — the `/health` endpoint only
+  reports whether the agent object is non-None. `--verify` resolves the same spec the
+  extension would run, loads it, and runs ONE real turn through the shared
+  `langstage-core` primitive `core.verify()`, exiting **0** if it completed cleanly /
+  **non-zero** otherwise (use `--demo` for a keyless check). Catches a missing key /
+  broken tool / bad graph before you launch. Requires `langstage-core>=1.0.6`.
+
 ## 0.6.2 - 2026-07-03
 
 ### Fixed

--- a/langstage_jupyter/launcher.py
+++ b/langstage_jupyter/launcher.py
@@ -36,6 +36,7 @@ Launcher options:
   -a, --agent SPEC   Agent to load (module:attr or path/to/file.py:attr).
   --demo             Use the built-in keyless demo agent (no API key).
   --show-config      Print the resolved configuration and exit.
+  --verify           Preflight the agent (run one real turn); exit 0/1. Then exit.
   --version, -V      Print the langstage-jupyter version and exit.
   -h, --help         Show this message and exit.
 
@@ -170,6 +171,37 @@ def main():
             )
         )
         return
+
+    # --verify: preflight the agent the extension WOULD run — resolve the spec the
+    # same way, load it, and run ONE real turn through the shared langstage-core
+    # primitive; exit 0 if it completed cleanly, non-zero otherwise. The extension's
+    # /health only checks the agent object is non-None; this proves it can actually
+    # complete a turn (a bad key / broken tool / bad graph fails here, not at first
+    # chat). Uses --demo for a keyless check. (ADR 0004)
+    if "--verify" in args:
+        from langstage_core.agui import verify as _core_verify
+        from langstage_jupyter.config import LabConfig
+
+        spec = str(LabConfig.resolve().agent_spec or "").strip()
+        try:
+            if spec:
+                from langstage_core import load_agent_spec
+
+                graph = load_agent_spec(spec)
+            else:
+                # No explicit spec -> the bundled default agent (same object the
+                # extension builds at import).
+                from langstage_jupyter.agent import agent as graph
+        except Exception as e:  # noqa: BLE001 - report a load failure cleanly
+            print(f"[fail] could not load agent: {e}")
+            sys.exit(1)
+
+        result = _core_verify(graph)
+        if result.ok:
+            print(f"[ ok ] agent verified: {result.reason}")
+            sys.exit(0)
+        print(f"[fail] agent verification failed: {result.reason}")
+        sys.exit(1)
 
     if agent_spec:
         print(f"Agent spec: {agent_spec}")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
     # AG-UI runtime (ag-ui-langgraph[fastapi] + uvicorn, via core's [agui] extra)
     # is a HARD runtime requirement. A bare `pip install langstage-jupyter` must
     # be able to run a turn.
-    "langstage-core[agui]>=1.0",
+    # >=1.0.6 for the shared preflight primitive core.verify() used by --verify.
+    "langstage-core[agui]>=1.0.6",
     "python-dotenv>=0.19.0",
     "deepagents>=0.1.0",
     # Direct top-level imports in langstage_jupyter/agent.py. Previously only
@@ -68,7 +69,7 @@ dev = [
 ]
 # Redundant since AG-UI moved into base deps (core 1.0); kept as a no-op alias so
 # existing `pip install langstage-jupyter[agui]` scripts/READMEs still resolve.
-agui = ["langstage-core[agui]>=1.0"]
+agui = ["langstage-core[agui]>=1.0.6"]
 
 [tool.hatch.version]
 source = "nodejs"

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -98,6 +98,11 @@ class TestLauncherHelpAndShowConfig:
         out = capsys.readouterr().out
         assert "foo.py:graph" in out  # not agent_spec=None
 
+    def test_help_lists_verify_flag(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["langstage-jupyter", "--help"])
+        main()
+        assert "--verify" in capsys.readouterr().out
+
     def test_show_config_omits_inert_host_port(self, monkeypatch, capsys):
         # The launcher never honors LANGSTAGE_HOST/PORT (JupyterLab uses --port /
         # auto-detect and binds localhost), so --show-config must not advertise
@@ -284,3 +289,36 @@ class TestPortHandling:
     def test_no_port_auto_injects_one(self, monkeypatch):
         calls = self._run_main(["--no-browser"], monkeypatch)
         assert calls["cmd"].count("--port") == 1  # exactly one, auto-detected
+
+
+class TestVerifyFlag:
+    """--verify preflights the agent with one real turn via core.verify (ADR 0004)."""
+
+    def test_verify_demo_passes_exit_zero(self, monkeypatch, capsys):
+        monkeypatch.setenv("LANGSTAGE_AGENT_SPEC", "")
+        monkeypatch.setenv("DEEPAGENT_AGENT_SPEC", "")
+        monkeypatch.setattr("sys.argv", ["langstage-jupyter", "--demo", "--verify"])
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 0
+        assert "agent verified" in capsys.readouterr().out
+
+    def test_verify_broken_agent_fails_exit_one(self, monkeypatch, capsys, tmp_path):
+        agent = tmp_path / "broken.py"
+        agent.write_text(
+            "from langgraph.graph import StateGraph, START, END, MessagesState\n"
+            "def boom(s):\n"
+            "    raise RuntimeError('tool exploded')\n"
+            "b = StateGraph(MessagesState)\n"
+            "b.add_node('boom', boom)\n"
+            "b.add_edge(START, 'boom')\n"
+            "b.add_edge('boom', END)\n"
+            "graph = b.compile()\n"
+        )
+        monkeypatch.setenv("LANGSTAGE_AGENT_SPEC", "")
+        monkeypatch.setenv("DEEPAGENT_AGENT_SPEC", "")
+        monkeypatch.setattr("sys.argv", ["langstage-jupyter", "-a", f"{agent}:graph", "--verify"])
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 1
+        assert "verification failed" in capsys.readouterr().out


### PR DESCRIPTION
Third surface adoption of the ADR 0004 shared preflight (`langstage-core` `verify()`, 1.0.6) — after cli `--verify` and web `check --live`.

### What
`langstage-jupyter --verify` resolves the same spec the extension would run, loads it, and runs **one real turn** through `core.verify()`, exiting **0** clean / **non-zero** otherwise. `--demo` gives a keyless check.

### Why
The extension had **no** real readiness check — the `/health` endpoint only reports whether the agent object is non-None (so a misconfigured agent that imports fine but fails on first turn reads "healthy"). `--verify` proves it can actually complete a turn before you launch:

```bash
langstage-jupyter --demo --verify      # keyless smoke -> [ ok ] agent verified
langstage-jupyter -a my_agent.py:graph --verify
```

### Tests
`tests/test_launcher.py`: `--demo --verify` exits 0 with "agent verified"; a runnable-but-broken agent (node raises) exits 1 with "verification failed"; `--help` lists `--verify`. 99 passed.

Version bumped to 0.6.3 (labextension rebuilt cleanly at publish; the new `labext-version` gate asserts parity). Backlog item 38 — remaining: hermes `doctor` (note: hermes `verify` already drives a real turn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)