### PR TITLE
feat: workspace flows through core.apply_workspace/workspace_root (ADR 0005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
-## 0.6.3 - 2026-07-03
+## 0.6.4 - 2026-07-03
+
+### Changed
+- **Workspace root now flows through the shared `core.apply_workspace()` /
+  `core.workspace_root()` source of truth (ADR 0005).** The extension used to apply
+  the workspace via a bespoke dance — a mutable `config.WORKSPACE_ROOT` global,
+  manual `os.environ` writes, and `set_root_dir()` mutating that global to re-root —
+  which drifted into #45 (pinned root discarded) and #36 (dead re-root). Now
+  `agent_wrapper` calls `apply_workspace()` (pinned root at init, else JupyterLab's
+  live launch dir on each message) and the default agent reads `workspace_root()` —
+  one source the env, the backend, and the rebuilt agent all agree on. Behavior is
+  preserved (pinned still wins over the launch dir; re-root still happens on an
+  actual change); the published env value is now the *resolved* absolute root.
+  Requires `langstage-core>=1.0.7`.
+
 
 ### Added
 - **`langstage-jupyter --verify`: preflight the agent with one real turn (ADR 0004).**

--- a/langstage_jupyter/agent.py
+++ b/langstage_jupyter/agent.py
@@ -16,6 +16,7 @@ from dotenv import find_dotenv, load_dotenv
 # finds the user's project .env. (gh #32)
 load_dotenv(find_dotenv(usecwd=True))
 
+from langstage_core import workspace_root
 from langstage_core.demo import create_default_agent as _build_default_agent
 from langchain.chat_models import init_chat_model
 
@@ -32,15 +33,12 @@ kernel_clients = {}
 
 # === Configuration ===
 
-# Workspace root comes from the resolved config (config.WORKSPACE_ROOT honors
-# canonical LANGSTAGE_WORKSPACE_ROOT, legacy DEEPAGENT_WORKSPACE_ROOT, and
-# langstage.toml with the correct precedence). Reading DEEPAGENT_WORKSPACE_ROOT
-# directly here used to override the canonical name — precedence inversion fixed
-# by deferring to config (gh #-dogfood).
-if config.WORKSPACE_ROOT:
-    WORKSPACE = config.WORKSPACE_ROOT
-else:
-    WORKSPACE = Path(".")
+# Workspace root comes from the shared source of truth (ADR 0005). The agent
+# wrapper calls core.apply_workspace() with the resolved root (pinned config root,
+# else JupyterLab's live launch dir) BEFORE this module builds/rebuilds the agent,
+# so workspace_root() here is authoritative — and honors canonical
+# LANGSTAGE_WORKSPACE_ROOT / legacy / langstage.toml with the correct precedence.
+WORKSPACE = workspace_root()
 
 # Get Jupyter server configuration
 JUPYTER_SERVER_URL = config.JUPYTER_SERVER_URL

--- a/langstage_jupyter/agent_wrapper.py
+++ b/langstage_jupyter/agent_wrapper.py
@@ -17,7 +17,7 @@ load_dotenv(find_dotenv(usecwd=True))
 
 # Import configuration.
 from . import config
-from langstage_core import load_agent_spec
+from langstage_core import apply_workspace, load_agent_spec, workspace_root
 
 
 class AgentWrapper:
@@ -62,21 +62,24 @@ class AgentWrapper:
             self.agent_module_path = agent_module_path or config.AGENT_MODULE
             self.agent_variable_name = agent_variable_name or config.AGENT_VARIABLE
 
-        self._load_agent()
         # Whether the operator pinned an explicit workspace root — via
         # LANGSTAGE_WORKSPACE_ROOT / legacy DEEPAGENT_WORKSPACE_ROOT, or
         # workspace.root in langstage.toml. config.WORKSPACE_ROOT is None only when
         # the source is "default" (unset). If pinned, set_root_dir() must honor it
-        # rather than silently re-rooting to JupyterLab's launch dir. Captured here
-        # because set_root_dir() itself mutates config.WORKSPACE_ROOT. (gh #45)
+        # rather than silently re-rooting to JupyterLab's launch dir. (gh #45)
         self._workspace_pinned = config.WORKSPACE_ROOT is not None
         self._pinned_root = str(config.WORKSPACE_ROOT) if config.WORKSPACE_ROOT else None
-        # The root the agent's backend was just built from (config.WORKSPACE_ROOT,
-        # else cwd "."). set_root_dir() compares against this so it only rebuilds
-        # when JupyterLab's live root actually differs. (gh #36)
-        self._applied_root = self._resolve_root(
-            str(config.WORKSPACE_ROOT) if config.WORKSPACE_ROOT else "."
-        )
+        # Apply the pinned root as the shared source of truth (ADR 0005) BEFORE
+        # loading the agent, so the default agent module builds its FilesystemBackend
+        # rooted there via core.workspace_root(). Unpinned: leave it — set_root_dir()
+        # applies JupyterLab's live launch dir on the first message.
+        if self._workspace_pinned:
+            apply_workspace(self._pinned_root)
+        self._load_agent()
+        # The root the agent's backend was just built from. set_root_dir() compares
+        # against this so it only rebuilds when JupyterLab's live root actually
+        # differs. (gh #36)
+        self._applied_root = self._resolve_root(self._pinned_root or ".")
 
     def _load_agent(self):
         """Load the agent via the shared host loader.
@@ -154,25 +157,20 @@ class AgentWrapper:
         """
         # Honor an explicitly pinned workspace root (LANGSTAGE_WORKSPACE_ROOT /
         # workspace.root in langstage.toml) — don't silently re-root to JupyterLab's
-        # launch dir. The auto-follow below is only for the default (unpinned) case,
-        # where following the live JupyterLab dir is the convenience. Publish the
-        # pinned root for agents that read it at runtime (setdefault so an explicit
-        # env value the operator already set is never clobbered). (gh #45)
+        # launch dir. The auto-follow below is only for the default (unpinned) case.
+        # Re-apply the pinned root as the source of truth (idempotent; re-publishes
+        # the env + active workspace). (gh #45, ADR 0005)
         if getattr(self, "_workspace_pinned", False):
             pinned = getattr(self, "_pinned_root", None)
             if pinned:
-                os.environ.setdefault("LANGSTAGE_WORKSPACE_ROOT", pinned)
-                os.environ.setdefault("DEEPAGENT_WORKSPACE_ROOT", pinned)
+                apply_workspace(pinned)
             return
 
-        # Publish BOTH the canonical and the legacy env name. The README's own
-        # custom-agent example reads canonical `LANGSTAGE_WORKSPACE_ROOT`, so a
-        # user following the docs verbatim would otherwise see "." instead of
-        # the live JupyterLab root — the agent's read path was renamed (0.5.4)
-        # but this write path still published only the deprecated name.
-        # (gh #-dogfood)
-        os.environ['LANGSTAGE_WORKSPACE_ROOT'] = root_dir
-        os.environ['DEEPAGENT_WORKSPACE_ROOT'] = root_dir
+        # Unpinned: follow JupyterLab's live launch dir. apply_workspace publishes it
+        # as the shared source of truth — the canonical + legacy env vars (the
+        # README's custom-agent example reads canonical LANGSTAGE_WORKSPACE_ROOT) and
+        # the active workspace core.workspace_root() the rebuilt agent reads. (ADR 0005)
+        apply_workspace(root_dir)
 
         # Re-root only on an actual change — set_root_dir runs on every message,
         # and rebuilding each time would be wasteful and reset agent state.
@@ -188,11 +186,14 @@ class AgentWrapper:
         if self.agent is not None and hasattr(self.agent, 'backend'):
             try:
                 from deepagents.backends import FilesystemBackend
+                # Root at the shared source of truth (the resolved root apply_workspace
+                # just published), so the backend, env, and workspace_root() agree.
+                applied = str(workspace_root())
                 self.agent.backend = FilesystemBackend(
-                    root_dir=root_dir,
+                    root_dir=applied,
                     virtual_mode=config.VIRTUAL_MODE,
                 )
-                print(f"Set agent backend root_dir to: {root_dir}")
+                print(f"Set agent backend root_dir to: {applied}")
                 return
             except ImportError:
                 pass
@@ -200,13 +201,12 @@ class AgentWrapper:
                 print(f"Warning: Could not set agent backend root_dir: {e}")
 
         # General path (the bundled default and `create_deep_agent` agents): their
-        # FilesystemBackend is built from `config.WORKSPACE_ROOT` at import time, so
-        # refresh that resolved value and rebuild the agent — its backend then
-        # re-roots at the live directory. Previously this branch was dead (wrong
-        # import + a guard that's never true for a CompiledStateGraph), so the
-        # documented re-root never happened. (gh #36)
+        # FilesystemBackend is built from `core.workspace_root()` at import time, so
+        # rebuild the agent — apply_workspace() above already updated the active
+        # workspace, so the reloaded agent module re-roots at the live directory.
+        # Previously this branch was dead (wrong import + a guard that's never true
+        # for a CompiledStateGraph), so the documented re-root never happened. (gh #36)
         try:
-            config.WORKSPACE_ROOT = Path(resolved)
             self.reload_agent()
             print(f"Re-rooted agent filesystem to: {root_dir}")
         except Exception as e:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     # is a HARD runtime requirement. A bare `pip install langstage-jupyter` must
     # be able to run a turn.
     # >=1.0.6 for the shared preflight primitive core.verify() used by --verify.
-    "langstage-core[agui]>=1.0.6",
+    "langstage-core[agui]>=1.0.7",
     "python-dotenv>=0.19.0",
     "deepagents>=0.1.0",
     # Direct top-level imports in langstage_jupyter/agent.py. Previously only
@@ -69,7 +69,7 @@ dev = [
 ]
 # Redundant since AG-UI moved into base deps (core 1.0); kept as a no-op alias so
 # existing `pip install langstage-jupyter[agui]` scripts/READMEs still resolve.
-agui = ["langstage-core[agui]>=1.0.6"]
+agui = ["langstage-core[agui]>=1.0.7"]
 
 [tool.hatch.version]
 source = "nodejs"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,21 +9,30 @@ from unittest.mock import Mock
 
 @pytest.fixture(autouse=True)
 def _restore_workspace_root():
-    """Snapshot + restore the module-level ``config.WORKSPACE_ROOT`` around each test.
+    """Snapshot + restore the process-global workspace state around each test.
 
-    ``set_root_dir()`` mutates this global (gh #36) to re-root the agent. In a real
-    session that's a fresh process, but under pytest the module persists, so the
-    mutation would leak into the next test — and trip the gh #45 pinned-workspace
-    detection, which reads ``config.WORKSPACE_ROOT`` at wrapper init. Restoring it
-    per test keeps isolation.
+    Two globals persist across tests under pytest (a real session is a fresh
+    process): ``config.WORKSPACE_ROOT`` (read at wrapper init for the gh #45 pinned
+    detection) and, since ADR 0005, ``langstage_core``'s active workspace + the
+    ``LANGSTAGE_WORKSPACE_ROOT`` / ``DEEPAGENT_WORKSPACE_ROOT`` env vars that
+    ``apply_workspace()`` publishes. Restoring all of them per test keeps isolation.
     """
     import langstage_jupyter.config as _cfg
+    from langstage_core.host import workspace as _ws
 
-    saved = _cfg.WORKSPACE_ROOT
+    saved_root = _cfg.WORKSPACE_ROOT
+    saved_active = _ws._ACTIVE
+    saved_env = {k: os.environ.get(k) for k in ("LANGSTAGE_WORKSPACE_ROOT", "DEEPAGENT_WORKSPACE_ROOT")}
     try:
         yield
     finally:
-        _cfg.WORKSPACE_ROOT = saved
+        _cfg.WORKSPACE_ROOT = saved_root
+        _ws._ACTIVE = saved_active
+        for k, v in saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
 
 
 @pytest.fixture

--- a/tests/test_agent_wrapper.py
+++ b/tests/test_agent_wrapper.py
@@ -151,20 +151,21 @@ class TestSetRootDir:
 
     @patch('langstage_jupyter.agent_wrapper.AgentWrapper._load_agent')
     @patch('os.environ', {})
-    def test_sets_environment_variable(self, mock_load):
+    def test_sets_environment_variable(self, mock_load, tmp_path):
         """Should publish BOTH the canonical and legacy workspace-root env vars.
 
         Since ADR 0005 the published value is the *resolved* absolute root (what
-        apply_workspace records as the source of truth), not the raw string.
+        apply_workspace records as the source of truth), not the raw string. Uses a
+        real dir — apply_workspace ensures the root exists (in a real session it's
+        JupyterLab's live launch dir, which always exists).
         """
         import os
-        from pathlib import Path
 
         wrapper = AgentWrapper()
         wrapper.agent = Mock()
 
-        wrapper.set_root_dir("/home/user/workspace")
-        expected = str(Path("/home/user/workspace").resolve())
+        wrapper.set_root_dir(str(tmp_path))
+        expected = str(tmp_path.resolve())
 
         # Canonical name is what the README's custom-agent example reads.
         assert os.environ['LANGSTAGE_WORKSPACE_ROOT'] == expected
@@ -172,7 +173,7 @@ class TestSetRootDir:
         assert os.environ['DEEPAGENT_WORKSPACE_ROOT'] == expected
 
     @patch('langstage_jupyter.agent_wrapper.AgentWrapper._load_agent')
-    def test_updates_agent_backend_if_available(self, mock_load):
+    def test_updates_agent_backend_if_available(self, mock_load, tmp_path):
         """Should update agent backend if it exists."""
         wrapper = AgentWrapper()
         mock_backend = Mock()
@@ -182,17 +183,17 @@ class TestSetRootDir:
 
         # Should not raise an error when agent has backend
         # FilesystemBackend update is optional and may fail if module not available
-        wrapper.set_root_dir("/new/root")
+        wrapper.set_root_dir(str(tmp_path / "new"))
 
     @patch('langstage_jupyter.agent_wrapper.AgentWrapper._load_agent')
-    def test_handles_agent_without_backend(self, mock_load):
+    def test_handles_agent_without_backend(self, mock_load, tmp_path):
         """Should handle agent without backend gracefully."""
         wrapper = AgentWrapper()
         mock_agent = Mock(spec=[])  # Agent without backend attribute
         wrapper.agent = mock_agent
 
         # Should not raise an error
-        wrapper.set_root_dir("/some/path")
+        wrapper.set_root_dir(str(tmp_path / "some"))
 
 
 class TestExecuteMethod:

--- a/tests/test_agent_wrapper.py
+++ b/tests/test_agent_wrapper.py
@@ -152,17 +152,24 @@ class TestSetRootDir:
     @patch('langstage_jupyter.agent_wrapper.AgentWrapper._load_agent')
     @patch('os.environ', {})
     def test_sets_environment_variable(self, mock_load):
-        """Should publish BOTH the canonical and legacy workspace-root env vars."""
+        """Should publish BOTH the canonical and legacy workspace-root env vars.
+
+        Since ADR 0005 the published value is the *resolved* absolute root (what
+        apply_workspace records as the source of truth), not the raw string.
+        """
         import os
+        from pathlib import Path
+
         wrapper = AgentWrapper()
         wrapper.agent = Mock()
 
         wrapper.set_root_dir("/home/user/workspace")
+        expected = str(Path("/home/user/workspace").resolve())
 
         # Canonical name is what the README's custom-agent example reads.
-        assert os.environ['LANGSTAGE_WORKSPACE_ROOT'] == "/home/user/workspace"
+        assert os.environ['LANGSTAGE_WORKSPACE_ROOT'] == expected
         # Legacy name stays set for back-compat with anything still reading it.
-        assert os.environ['DEEPAGENT_WORKSPACE_ROOT'] == "/home/user/workspace"
+        assert os.environ['DEEPAGENT_WORKSPACE_ROOT'] == expected
 
     @patch('langstage_jupyter.agent_wrapper.AgentWrapper._load_agent')
     def test_updates_agent_backend_if_available(self, mock_load):

--- a/tests/test_reroot.py
+++ b/tests/test_reroot.py
@@ -99,3 +99,28 @@ def test_pinned_workspace_root_is_honored(monkeypatch, tmp_path):
 
 def test_resolve_root_normalizes():
     assert AgentWrapper._resolve_root(".") == str(Path(".").resolve())
+
+
+def test_set_root_dir_updates_workspace_source_of_truth(tmp_path):
+    # ADR 0005: after re-rooting, core.workspace_root() (which the rebuilt agent
+    # reads) reflects the live launch dir — one source of truth, not a private global.
+    from langstage_core import workspace_root
+
+    w = _wrapper(".", object())
+    w.reload_agent = lambda: None
+    w.set_root_dir(str(tmp_path))
+    assert workspace_root() == tmp_path.resolve()
+
+
+def test_pinned_root_is_the_source_of_truth(tmp_path):
+    # ADR 0005 + gh #45: a pinned root stays authoritative; the live JupyterLab dir
+    # does NOT override it.
+    from langstage_core import workspace_root
+
+    pinned = tmp_path / "pinned"
+    w = _wrapper(str(pinned), object())
+    w._workspace_pinned = True
+    w._pinned_root = str(pinned)
+    w.reload_agent = lambda: None
+    w.set_root_dir(str(tmp_path / "jupyter_launch_dir"))
+    assert workspace_root() == pinned.resolve()


### PR DESCRIPTION
Fourth surface migration for ADR 0005 (workspace application in core, `langstage-core` 1.0.7) — the most involved, because jupyter's apply logic was the tangled `#45/#36` code.

### What
Replaces the extension's bespoke workspace-apply mechanism — a mutable `config.WORKSPACE_ROOT` global, manual `os.environ` writes, and `set_root_dir()` mutating that global to re-root — with the shared source of truth:
- `agent_wrapper.__init__` calls `apply_workspace(pinned)` **before** loading the agent (so the default agent module builds its backend rooted there).
- `set_root_dir()` calls `apply_workspace()` — pinned root (idempotent) or JupyterLab's live launch dir — and drops the `config.WORKSPACE_ROOT` mutation.
- `agent.py` reads `core.workspace_root()` instead of `config.WORKSPACE_ROOT`, so the env, the backend, and every `reload_agent()` agree on one root.

### Behavior preserved
The `#45` pinned-root-wins and `#36` re-root-on-change semantics are unchanged — all of `test_reroot.py` passes as-is. One intentional change: the published env value is now the **resolved absolute** root (matching the other surfaces), so `test_sets_environment_variable` was updated to expect the resolved path.

### Tests
- All `#45/#36` regression tests green unchanged.
- New `test_reroot.py` cases assert the ADR 0005 contract directly: after `set_root_dir`, `workspace_root()` reflects the live dir; a pinned root stays authoritative.
- `conftest.py` now also snapshots/restores core's active workspace + env (process-global state).
- **99 passed.** Bumps core floor to `>=1.0.7`; version → 0.6.4 (labextension rebuilt cleanly at publish, verified by the `labext-version` gate).

Migration order: cli ✓ → vscode ✓ → hermes ✓ → **jupyter** (this) → web (last).

🤖 Generated with [Claude Code](https://claude.com/claude-code)