### PR TITLE
fix: empty POST body returns 400, not 500 (gh #53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.6.5 - 2026-07-04
+
+### Fixed
+- **Empty POST body to `/chat`, `/resume`, `/cancel` returned HTTP 500 instead of
+  400 (gh #53).** Jupyter Server's `get_json_body()` returns `None` for an empty
+  body (it only raises on *invalid* JSON), so the handlers hit `None.get(...)` →
+  unhandled `AttributeError` → 500. All three now guard `data is None` and raise
+  `HTTPError(400, "Request body must be a JSON object")`, matching the adjacent
+  malformed-input handling. Reachable from a frontend race, a proxy that drops the
+  body, or a stray client.
+
 ## 0.6.4 - 2026-07-03
 
 ### Changed

--- a/langstage_jupyter/handlers.py
+++ b/langstage_jupyter/handlers.py
@@ -40,6 +40,10 @@ class ChatHandler(APIHandler):
         try:
             # Parse request body
             data = self.get_json_body()
+            # get_json_body() returns None for an EMPTY body (it only raises on
+            # invalid JSON), so guard before .get() or an empty POST 500s. (gh #53)
+            if data is None:
+                raise HTTPError(400, "Request body must be a JSON object")
             message = data.get("message")
             thread_id = data.get("thread_id")
             current_directory = data.get("current_directory", "")
@@ -169,6 +173,8 @@ class ResumeHandler(APIHandler):
         """
         try:
             data = self.get_json_body()
+            if data is None:  # empty body -> 400, not a 500 on None.get() (gh #53)
+                raise HTTPError(400, "Request body must be a JSON object")
             decisions = data.get("decisions", [])
             thread_id = data.get("thread_id")
 
@@ -300,6 +306,8 @@ class CancelHandler(APIHandler):
         """
         try:
             data = self.get_json_body()
+            if data is None:  # empty body -> 400, not a 500 on None.get() (gh #53)
+                raise HTTPError(400, "Request body must be a JSON object")
             thread_id = data.get("thread_id")
 
             if not thread_id:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/tests/test_empty_body.py
+++ b/tests/test_empty_body.py
@@ -1,0 +1,30 @@
+"""Empty POST body returns 400, not a 500 on None.get() (gh #53).
+
+Jupyter Server's get_json_body() returns None for an EMPTY body (it only raises
+on invalid JSON), so ChatHandler/ResumeHandler/CancelHandler used to hit
+None.get(...) -> AttributeError -> HTTP 500. They now guard and raise HTTPError(400).
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from tornado.web import Application, HTTPError
+
+from langstage_jupyter.handlers import CancelHandler, ChatHandler, ResumeHandler
+
+
+def _handler(cls):
+    h = cls(Application(), MagicMock())
+    h._jupyter_current_user = "test"  # satisfy @web.authenticated without real auth
+    h._current_user = "test"  # tornado's cache, so current_user won't call get_current_user
+    h.get_json_body = lambda: None  # simulate an empty request body
+    return h
+
+
+@pytest.mark.parametrize("cls", [ChatHandler, ResumeHandler, CancelHandler])
+def test_empty_body_is_400_not_500(cls):
+    h = _handler(cls)
+    with pytest.raises(HTTPError) as exc:
+        asyncio.run(h.post())
+    assert exc.value.status_code == 400, f"{cls.__name__} should 400 on an empty body"


### PR DESCRIPTION
Closes #53.

Jupyter Server's `get_json_body()` returns `None` for an **empty** body (it only raises on *invalid* JSON), so `ChatHandler`/`ResumeHandler`/`CancelHandler` hit `None.get(...)` → unhandled `AttributeError` → **HTTP 500** on a trivially-reachable input (frontend race, a proxy dropping the body, a stray client).

All three now guard `data is None` and raise `HTTPError(400, "Request body must be a JSON object")` — matching the adjacent malformed-input handling (each handler already re-raises `HTTPError` before its `except Exception`, so the 400 propagates).

`tests/test_empty_body.py`: each handler returns 400 (not 500) on an empty body. 104 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)