### PR TITLE
feat: rebrand the chat sidebar "LangStage" (was "Deep Agents") + refresh header (dogfood)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## 0.6.5 - 2026-07-04
+## 0.6.6 - 2026-07-04
+
+### Changed
+- **The chat sidebar is now branded "LangStage", not "Deep Agents" (dogfood).** The
+  JupyterLab left-rail tab tooltip, launcher entry, and default agent-name fallback all
+  said "Deep Agents" (the pre-rename name); they now read "LangStage". Command IDs and
+  CSS classes (`deepagents:open-chat`, `.deepagents-*`) are unchanged, so nothing that
+  targets them breaks.
+
+### Docs
+- Refreshed the README header to a `langstage-jupyter` SVG banner (was a remote
+  `cover.png` labelled "DeepAgent Lab", the old name).
 
 ### Fixed
 - **Empty POST body to `/chat`, `/resume`, `/cancel` returned HTTP 500 instead of

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://storage.googleapis.com/deepagents/cover.png" alt="DeepAgent Lab" width=600>
+  <img src="assets/header.svg" alt="langstage-jupyter — chat with your LangGraph agent inside JupyterLab" width="100%">
 </p>
 
 <p align="center">

--- a/assets/header.svg
+++ b/assets/header.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="340" viewBox="0 0 1280 340" role="img" aria-label="langstage-jupyter — chat with your LangGraph agent inside JupyterLab">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0B1221"/>
+      <stop offset="1" stop-color="#1A1226"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#F37726"/>
+      <stop offset="1" stop-color="#7C5CFF"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.82" cy="0.15" r="0.6">
+      <stop offset="0" stop-color="#F37726" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#F37726" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1280" height="340" rx="20" fill="url(#bg)"/>
+  <rect width="1280" height="340" rx="20" fill="url(#glow)"/>
+  <rect x="1" y="1" width="1278" height="338" rx="19" fill="none" stroke="#2E2A44" stroke-width="1.5"/>
+
+  <!-- ===== left: identity ===== -->
+  <g transform="translate(72,66)">
+    <rect width="140" height="34" rx="17" fill="#241A2E" stroke="url(#accent)" stroke-width="1.5"/>
+    <circle cx="22" cy="17" r="5" fill="url(#accent)"/>
+    <text x="38" y="23" font-family="'SF Mono','JetBrains Mono','Consolas',monospace" font-size="15" fill="#F6C8A6">JupyterLab</text>
+  </g>
+
+  <text x="70" y="178" font-family="'SF Mono','JetBrains Mono','Consolas',monospace" font-size="54" font-weight="700" fill="#F2F6FC" letter-spacing="-1">langstage-<tspan fill="url(#accent)">jupyter</tspan></text>
+
+  <text x="72" y="222" font-family="'Segoe UI',Helvetica,Arial,sans-serif" font-size="22" fill="#B7A8C6">Chat with your LangGraph agent inside</text>
+  <text x="72" y="252" font-family="'Segoe UI',Helvetica,Arial,sans-serif" font-size="22" fill="#B7A8C6">JupyterLab &#8212; right beside your notebooks.</text>
+
+  <g font-family="'SF Mono','JetBrains Mono','Consolas',monospace" font-size="13" fill="#8A7C9A">
+    <text x="72" y="300">sidebar chat</text>
+    <text x="188" y="300" fill="#4A3F5A">&#8226;</text>
+    <text x="208" y="300">workspace</text>
+    <text x="300" y="300" fill="#4A3F5A">&#8226;</text>
+    <text x="320" y="300">notebook context</text>
+  </g>
+
+  <!-- ===== right: JupyterLab mock (sidebar chat + notebook) ===== -->
+  <g transform="translate(788,70)">
+    <rect width="424" height="200" rx="12" fill="#0E1220" stroke="#2E2A44" stroke-width="1.5"/>
+    <!-- left rail -->
+    <rect width="34" height="200" rx="12" fill="#141020"/>
+    <rect x="22" width="12" height="200" fill="#141020"/>
+    <rect x="9" y="16" width="16" height="16" rx="3" fill="#2A2440"/>
+    <rect x="9" y="40" width="16" height="16" rx="3" fill="#F37726" opacity="0.85"/>
+    <rect x="9" y="64" width="16" height="16" rx="3" fill="#2A2440"/>
+    <!-- notebook area -->
+    <g transform="translate(48,16)">
+      <rect width="220" height="26" rx="6" fill="#12182A" stroke="#26314C" stroke-width="1"/>
+      <text x="10" y="17" font-family="'SF Mono','Consolas',monospace" font-size="10" fill="#6EA8FF">In [1]: df.describe()</text>
+      <rect y="34" width="220" height="40" rx="6" fill="#0C1424"/>
+      <rect x="10" y="46" width="150" height="6" rx="3" fill="#26314C"/>
+      <rect x="10" y="58" width="120" height="6" rx="3" fill="#26314C"/>
+    </g>
+    <!-- chat sidebar -->
+    <line x1="288" y1="0" x2="288" y2="200" stroke="#2E2A44" stroke-width="1"/>
+    <g transform="translate(300,16)">
+      <text x="0" y="8" font-family="'SF Mono','Consolas',monospace" font-size="10" fill="#8A7C9A" letter-spacing="1">LANGSTAGE</text>
+      <rect x="20" y="20" width="90" height="18" rx="8" fill="#1A2338"/>
+      <rect y="46" width="10" height="10" rx="5" fill="url(#accent)"/>
+      <rect x="16" y="48" width="100" height="7" rx="3.5" fill="#2A2A44"/>
+      <rect x="16" y="60" width="80" height="7" rx="3.5" fill="#2A2A44"/>
+      <rect x="0" y="150" width="112" height="24" rx="8" fill="#12182A" stroke="#3A3358" stroke-width="1"/>
+      <text x="12" y="166" font-family="'Segoe UI',Arial,sans-serif" font-size="10" fill="#6C6486">Ask about this notebook…</text>
+    </g>
+  </g>
+</svg>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ namespace CommandIDs {
  */
 const plugin: JupyterFrontEndPlugin<void> = {
   id: 'langstage-jupyter:plugin',
-  description: 'A JupyterLab extension for DeepAgents chat interface',
+  description: 'A JupyterLab extension for LangStage chat interface',
   autoStart: true,
   optional: [ICommandPalette, IFileBrowserFactory],
   activate: (
@@ -42,15 +42,15 @@ const plugin: JupyterFrontEndPlugin<void> = {
     widget.title.label = ''; // Remove label from sidebar, show only icon
     widget.title.icon = chatIcon;
     widget.title.closable = true;
-    widget.title.caption = 'Deep Agents'; // Tooltip on hover
+    widget.title.caption = 'LangStage'; // Tooltip on hover
 
     // Add to right sidebar at the bottom (high rank value)
     app.shell.add(widget, 'right', { rank: 1000 });
 
     // Add command to open chat (useful if user closes the widget)
     app.commands.addCommand(CommandIDs.openChat, {
-      label: 'Deep Agents',
-      caption: 'Open DeepAgents chat interface',
+      label: 'LangStage',
+      caption: 'Open LangStage chat interface',
       icon: chatIcon,
       execute: () => {
         if (!widget.isAttached) {
@@ -64,11 +64,11 @@ const plugin: JupyterFrontEndPlugin<void> = {
     if (palette) {
       palette.addItem({
         command: CommandIDs.openChat,
-        category: 'Deep Agents'
+        category: 'LangStage'
       });
     }
 
-    console.log('DeepAgents chat interface ready');
+    console.log('LangStage chat interface ready');
   }
 };
 

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -91,7 +91,7 @@ const ChatComponent: React.FC<ChatComponentProps> = ({ shell, browserFactory, on
   const [inputValue, setInputValue] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [agentStatus, setAgentStatus] = useState<'unknown' | 'healthy' | 'error'>('unknown');
-  const [agentName, setAgentName] = useState<string>('Deep Agents');
+  const [agentName, setAgentName] = useState<string>('LangStage');
   const [threadId, setThreadId] = useState<string>(() => crypto.randomUUID());
   const [awaitingDecision, setAwaitingDecision] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -121,7 +121,7 @@ const ChatComponent: React.FC<ChatComponentProps> = ({ shell, browserFactory, on
         setAgentStatus('healthy');
 
         // Update agent name if available
-        const name = response.agent_name || 'Deep Agents';
+        const name = response.agent_name || 'LangStage';
         setAgentName(name);
         if (onAgentNameChange) {
           onAgentNameChange(name);

--- a/ui-tests/tests/langstage-jupyter.spec.ts
+++ b/ui-tests/tests/langstage-jupyter.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@jupyterlab/galata';
 
 /**
- * Smoke test: open the Deep Agents chat sidebar, confirm it connects to the
+ * Smoke test: open the LangStage chat sidebar, confirm it connects to the
  * (stub) agent, send a message, and verify the streamed reply renders.
  *
  * The backend agent is the model-free stub (see stub_agent.py), so this runs


### PR DESCRIPTION
The JupyterLab chat sidebar's tab tooltip, launcher entry, and default agent-name fallback all read **"Deep Agents"** (the pre-rename name) — a fresh user installing `langstage-jupyter` sees the old brand. Now "LangStage".

Command IDs and CSS classes (`deepagents:open-chat`, `.deepagents-*`) are **unchanged**, so the ui-test selectors and anything targeting them still work (only user-visible labels changed).

Also refreshed the README header to a `langstage-jupyter` SVG banner (was a remote `cover.png` labelled "DeepAgent Lab"). 104 Python tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)