### PR TITLE
fix: --serve-check works as root (CI/Docker) + surfaces the real error (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.6.8 - 2026-07-06
+
+### Fixed
+- **`--serve-check` now works when running as root — i.e. in CI and Docker, the
+  environments it targets (gh #58).** `serve_check()` spawned its `jupyter_server`
+  without `--allow-root`, so the server hit Jupyter's root guard and exited before it
+  could serve; the spawned server now passes `--ServerApp.allow_root=True` (safe: an
+  ephemeral, token-gated, localhost-only smoke server). And when the server exits before
+  it is ready, the verdict now includes the server's own last output lines (the real
+  cause — a root guard, a port clash, a config error) instead of a bare exit code.
+
 ## 0.6.7 - 2026-07-05
 
 ### Added

--- a/langstage_jupyter/launcher.py
+++ b/langstage_jupyter/launcher.py
@@ -205,6 +205,11 @@ def serve_check(agent_spec=None, *, boot_timeout=45.0, turn_timeout=60.0):
             f"--ServerApp.port={port}",
             f"--ServerApp.token={token}",
             "--ServerApp.open_browser=False",
+            # CI runners and Docker images commonly run as root, and jupyter_server
+            # refuses to boot as root without this — so serve-check died before it
+            # could serve in exactly the environments it targets (gh #58). Safe here:
+            # an ephemeral, token-gated, localhost-only server we spawn and tear down.
+            "--ServerApp.allow_root=True",
             # Local ephemeral smoke-test server; token auth already gates it and
             # exempts XSRF, but disable the check so the POST can't 403 on it.
             "--ServerApp.disable_check_xsrf=True",
@@ -214,14 +219,27 @@ def serve_check(agent_spec=None, *, boot_timeout=45.0, turn_timeout=60.0):
         stderr=subprocess.STDOUT,
         text=True,
     )
+
+    def _server_output_tail(n=6):
+        """The last few lines the (now-exited) server wrote — so the real cause
+        (a bad port, a config error, the root guard) is shown, not just a code
+        (gh #58: the diagnostic used to be swallowed)."""
+        try:
+            out = proc.stdout.read() if proc.stdout else ""
+        except (ValueError, OSError):  # pragma: no cover - stream already closed
+            return ""
+        lines = [ln for ln in (out or "").splitlines() if ln.strip()]
+        return ("\n  " + "\n  ".join(lines[-n:])) if lines else ""
+
     try:
         # 1. Poll health until the agent is loaded (server boot + agent import).
         deadline = time.monotonic() + boot_timeout
         health = None
         while time.monotonic() < deadline:
             if proc.poll() is not None:  # server died before serving
-                print("[fail] serve-check: jupyter server exited before it was ready "
-                      f"(code {proc.returncode})")
+                tail = _server_output_tail()
+                print(f"[fail] serve-check: jupyter server exited before it was ready "
+                      f"(code {proc.returncode}){' — last output:' + tail if tail else ''}")
                 return 1
             try:
                 health = json.loads(_request("/health", timeout=3.0).read())

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -402,6 +402,64 @@ class TestServeCheckRouting:
         assert "--serve-check" in capsys.readouterr().out
 
 
+class TestServeCheckServerSpawn:
+    """serve_check() must boot the server so it works in CI/Docker (as root), and
+    surface the server's own output when it dies before serving (gh #58)."""
+
+    class _DeadProc:
+        """A spawned server that exited immediately, with captured output."""
+
+        returncode = 1
+
+        def __init__(self, output):
+            import io
+
+            self.stdout = io.StringIO(output)
+
+        def poll(self):
+            return self.returncode  # already exited
+
+        def terminate(self):
+            pass
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+        def kill(self):
+            pass
+
+    def _run_with_fake_server(self, monkeypatch, output):
+        captured = {}
+
+        def fake_popen(argv, **kwargs):
+            captured["argv"] = argv
+            return self._DeadProc(output)
+
+        monkeypatch.setattr("langstage_jupyter.launcher.subprocess.Popen", fake_popen)
+        monkeypatch.setattr("langstage_jupyter.launcher.find_available_port", lambda *a, **k: 12321)
+        code = serve_check(DEMO_AGENT_SPEC, boot_timeout=1.0)
+        return code, captured["argv"]
+
+    def test_spawns_server_with_allow_root(self, monkeypatch, capsys):
+        # gh #58: CI/Docker run as root; jupyter_server refuses to boot as root
+        # without allow_root, so the spawned server MUST carry it.
+        code, argv = self._run_with_fake_server(monkeypatch, "boom\n")
+        assert code == 1  # our fake server "died", so the check fails...
+        assert any("allow_root=True" in a for a in argv), argv  # ...but with the flag set
+
+    def test_early_exit_surfaces_server_output(self, monkeypatch, capsys):
+        # gh #58: the real cause used to be swallowed — the verdict must include the
+        # server's own last lines (e.g. the root guard), not just an exit code.
+        code, _ = self._run_with_fake_server(
+            monkeypatch,
+            "some noise\nRunning as root is not recommended. Use --allow-root to bypass.\n",
+        )
+        out = capsys.readouterr().out
+        assert code == 1
+        assert "exited before it was ready" in out
+        assert "Running as root" in out  # the actual diagnostic is now shown
+
+
 @pytest.mark.skipif(
     os.environ.get("RUN_SERVE_CHECK_IT") != "1",
     reason="real jupyter-server boot; opt in with RUN_SERVE_CHECK_IT=1 (kept out of the "


### PR DESCRIPTION
Closes #58 (nightly dogfood — a gap in the `--serve-check` shipped yesterday in 0.6.7).

`--serve-check` is pitched as "handy in CI or before a deploy," but it **failed
unconditionally as root** — the default in most CI runners and Docker images. Two defects:

1. **No `--allow-root`.** `serve_check()` spawned `jupyter_server` without it, so the
   server hit Jupyter's *"Running as root is not recommended"* guard and exited (code 1)
   before it could serve — and passing `--allow-root` on the CLI didn't help (serve_check
   builds a fixed argv and never forwards passthrough args).
2. **The real cause was swallowed.** The subprocess output was captured but discarded on
   the early-exit path, so the user saw only `code 1` with no diagnostic.

**Fix:**
- The spawned server now carries `--ServerApp.allow_root=True` — safe: it's an ephemeral,
  token-gated, localhost-only server we spawn and immediately tear down.
- The "exited before it was ready" verdict now includes the server's last output lines
  (the root guard, a port clash, a config error), instead of a bare exit code.

Tests (mock the spawn, no real boot): assert the argv carries `allow_root=True`, and that
an early exit surfaces the captured output. The real-boot e2e (`RUN_SERVE_CHECK_IT=1`)
still passes. Ships as **0.6.8**.