### PR TITLE
fix: sidebar readiness reflects can-run-a-turn, not just loaded (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## 0.6.8 - 2026-07-06
+## 0.6.9 - 2026-07-07
+
+### Fixed
+- **The sidebar status no longer shows 🟢 "ready" for an agent that can't actually run a
+  turn (gh #60).** Readiness was `agent is not None`, but the bundled default agent's model
+  is built lazily — it constructs fine with no `ANTHROPIC_API_KEY` and only fails at the
+  first API call — so a common first-run (no key) lit green, then the first message failed
+  with a raw provider auth error. Readiness now reflects runnability: the `/health` endpoint
+  returns a `ready` flag gated on the agent being a runnable graph **and** (for the default
+  agent) its provider key being present, and the sidebar shows a distinct 🟠 `needs_setup`
+  state with an actionable tooltip (e.g. "ANTHROPIC_API_KEY is not set — the first turn will
+  fail") instead of green. A custom/BYO agent's credentials remain the operator's concern.
 
 ### Fixed
 - **`--serve-check` now works when running as root — i.e. in CI and Docker, the

--- a/README.md
+++ b/README.md
@@ -228,10 +228,10 @@ See [.env.example](https://github.com/dkedar7/langstage-jupyter/blob/main/.env.e
 
 - **⟳ Reload**: Reload your agent without restarting JupyterLab (useful during agent development)
 - **Clear**: Start a new conversation thread
-- **Status Indicator**:
-  - 🟢 Green: Agent ready
-  - 🟠 Orange: Agent loading
-  - 🔴 Red: Agent error
+- **Status Indicator** (hover for details):
+  - 🟢 Green: Agent ready — it can actually run a turn
+  - 🟠 Orange: Loaded but not ready — e.g. the default agent's `ANTHROPIC_API_KEY` isn't set (the first turn would fail), or an uncompiled graph was exported. The tooltip says what to fix.
+  - 🔴 Red: Agent error — the agent module didn't load
 
 ## Development
 

--- a/langstage_jupyter/handlers.py
+++ b/langstage_jupyter/handlers.py
@@ -3,6 +3,7 @@ HTTP request handlers for the DeepAgents extension.
 """
 import asyncio
 import json
+import os
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, Dict
@@ -20,6 +21,73 @@ _executor = ThreadPoolExecutor(max_workers=4)
 # Track active executions and their cancellation flags
 _active_executions: Dict[str, threading.Event] = {}
 _execution_lock = threading.Lock()
+
+# The standard env var each model provider needs — for a cheap credential preflight so
+# the sidebar doesn't report "ready" for the bundled default agent when its key is
+# missing and the first turn would fail with a raw provider auth error (gh #60).
+_PROVIDER_KEY_ENV = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "azure_openai": "AZURE_OPENAI_API_KEY",
+    "google_genai": "GOOGLE_API_KEY",
+    "google_vertexai": "GOOGLE_API_KEY",
+    "groq": "GROQ_API_KEY",
+    "mistralai": "MISTRAL_API_KEY",
+    "cohere": "COHERE_API_KEY",
+    "fireworks": "FIREWORKS_API_KEY",
+    "together": "TOGETHER_API_KEY",
+    "xai": "XAI_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+}
+
+
+def _missing_default_agent_key() -> Optional[str]:
+    """The provider key the BUNDLED default agent needs, if it is absent.
+
+    The default agent's model is built lazily via ``init_chat_model(MODEL_NAME)``, so the
+    object constructs fine with no key and only fails at the first API call — which is why
+    readiness (`agent is not None`) read "ready" while the first turn died with a provider
+    auth error (gh #60). A custom/BYO agent's credentials are the operator's concern, so
+    this preflight is scoped to the default agent, where the model spec (and thus the
+    required key) is known.
+    """
+    from . import config
+
+    if config.AGENT_SPEC:  # a custom agent was configured -> not our concern
+        return None
+    model_name = (getattr(config, "MODEL_NAME", "") or "").strip()
+    provider = model_name.split(":", 1)[0].lower() if ":" in model_name else ""
+    env_var = _PROVIDER_KEY_ENV.get(provider)
+    if env_var and not os.environ.get(env_var):
+        return env_var
+    return None
+
+
+def _agent_readiness():
+    """Assess whether the loaded agent can actually run a turn (gh #60, #69).
+
+    Returns ``(status, ready, message)``. "loaded" (`agent is not None`) is not enough:
+    an uncompiled graph loads but has no ``astream``, and the default agent loads without
+    its provider key but fails on the first turn. Readiness reflects both.
+    """
+    agent = get_agent()
+    obj = getattr(agent, "agent", None)
+    if obj is None:
+        return "agent_not_loaded", False, "Agent module not found or failed to load"
+    if not callable(getattr(obj, "astream", None)):
+        return (
+            "not_runnable",
+            False,
+            "Loaded, but not a runnable graph — export a compiled graph (call .compile()).",
+        )
+    missing = _missing_default_agent_key()
+    if missing:
+        return (
+            "needs_setup",
+            False,
+            f"Loaded, but {missing} is not set — the first turn will fail. Set it and reload.",
+        )
+    return "healthy", True, "Agent is ready"
 
 
 class ChatHandler(APIHandler):
@@ -258,30 +326,26 @@ class HealthHandler(APIHandler):
 
     @tornado.web.authenticated
     async def get(self):
-        """Check agent health status."""
+        """Report readiness — whether the agent can actually run a turn, not merely
+        whether the object loaded (gh #60). ``ready`` gates the sidebar 🟢 indicator;
+        ``agent_loaded`` stays accurate (the object is present) for back-compat.
+        """
         try:
             agent = get_agent()
             is_loaded = agent.agent is not None
+            status, ready, message = _agent_readiness()
 
             # Try to get agent name if available
             agent_name = None
-            if is_loaded:
-                # Debug: log what attributes the agent has
-                self.log.info(f"Agent type: {type(agent.agent)}")
-
-                if hasattr(agent.agent, 'name'):
-                    agent_name = agent.agent.name
-                    self.log.info(f"Found agent name: {agent_name}")
-                else:
-                    self.log.info("Agent does not have 'name' attribute")
+            if is_loaded and hasattr(agent.agent, "name"):
+                agent_name = agent.agent.name
 
             response = {
-                "status": "healthy" if is_loaded else "agent_not_loaded",
+                "status": status,
                 "agent_loaded": is_loaded,
-                "message": "Agent is ready" if is_loaded else "Agent module not found or failed to load"
+                "ready": ready,
+                "message": message,
             }
-
-            # Include agent name if available
             if agent_name:
                 response["agent_name"] = agent_name
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -90,7 +90,8 @@ const ChatComponent: React.FC<ChatComponentProps> = ({ shell, browserFactory, on
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputValue, setInputValue] = useState('');
   const [isLoading, setIsLoading] = useState(false);
-  const [agentStatus, setAgentStatus] = useState<'unknown' | 'healthy' | 'error'>('unknown');
+  const [agentStatus, setAgentStatus] = useState<'unknown' | 'healthy' | 'needs_setup' | 'error'>('unknown');
+  const [agentStatusMessage, setAgentStatusMessage] = useState<string>('');
   const [agentName, setAgentName] = useState<string>('LangStage');
   const [threadId, setThreadId] = useState<string>(() => crypto.randomUUID());
   const [awaitingDecision, setAwaitingDecision] = useState(false);
@@ -117,7 +118,13 @@ const ChatComponent: React.FC<ChatComponentProps> = ({ shell, browserFactory, on
         method: 'GET'
       });
 
-      if (response.agent_loaded) {
+      // `ready` (not merely `agent_loaded`) gates the 🟢 indicator: the agent can
+      // actually run a turn. A loaded-but-not-ready agent — an uncompiled graph, or the
+      // default agent with no provider key — shows a distinct 🟠 state with an actionable
+      // message instead of a green "ready" that fails on the first turn (gh #60).
+      const message = response.message || '';
+      setAgentStatusMessage(message);
+      if (response.ready) {
         setAgentStatus('healthy');
 
         // Update agent name if available
@@ -128,13 +135,21 @@ const ChatComponent: React.FC<ChatComponentProps> = ({ shell, browserFactory, on
         }
 
         addSystemMessage('Agent is ready and connected');
+      } else if (response.agent_loaded) {
+        // Loaded, but not runnable yet (e.g. missing API key) — amber, not green.
+        setAgentStatus('needs_setup');
+        if (response.agent_name) {
+          setAgentName(response.agent_name);
+        }
+        addSystemMessage(message || 'Agent loaded but not ready to run a turn.');
       } else {
         setAgentStatus('error');
-        addSystemMessage('Agent not loaded. Please ensure agent.py is configured correctly.');
+        addSystemMessage(message || 'Agent not loaded. Please ensure agent.py is configured correctly.');
       }
     } catch (error) {
       console.error('Error checking agent health:', error);
       setAgentStatus('error');
+      setAgentStatusMessage('Failed to connect to agent service');
       addSystemMessage('Failed to connect to agent service');
     }
   };
@@ -684,7 +699,10 @@ const ChatComponent: React.FC<ChatComponentProps> = ({ shell, browserFactory, on
         <div className="deepagents-chat-controls">
           <span
             className={`deepagents-status-indicator deepagents-status-${agentStatus}`}
-            title={agentStatus === 'healthy' ? 'Agent connected' : 'Agent not available'}
+            title={
+              agentStatusMessage ||
+              (agentStatus === 'healthy' ? 'Agent connected' : 'Agent not available')
+            }
           />
           <button
             className="deepagents-icon-button"

--- a/style/base.css
+++ b/style/base.css
@@ -145,6 +145,11 @@
   background-color: var(--da-error);
 }
 
+/* Loaded, but not ready to run a turn (e.g. missing API key) — amber, not green (gh #60). */
+.deepagents-status-needs_setup {
+  background-color: var(--da-warning);
+}
+
 .deepagents-status-unknown {
   background-color: var(--da-warning);
 }

--- a/tests/test_health_readiness.py
+++ b/tests/test_health_readiness.py
@@ -1,0 +1,81 @@
+"""Sidebar readiness reflects whether the agent can run a turn, not just loaded (gh #60).
+
+`HealthHandler` reported `agent_loaded = agent is not None`, so the bundled default agent
+with no `ANTHROPIC_API_KEY` (a common first-run slip) showed 🟢 "ready" and then failed the
+first turn with a provider auth error. Readiness now gates on runnability + a cheap
+credential preflight for the default agent's provider, surfacing a distinct `needs_setup`
+state (amber) with an actionable message.
+"""
+
+import langstage_jupyter.handlers as handlers
+
+
+class _RunnableGraph:
+    async def astream(self, *a, **k):  # a compiled graph has astream
+        yield {}
+
+    name = "default-agent"
+
+
+class _Uncompiled:
+    def compile(self):  # a StateGraph builder: has compile, no astream
+        pass
+
+
+def _use_agent(monkeypatch, obj):
+    monkeypatch.setattr(handlers, "get_agent", lambda: type("W", (), {"agent": obj})())
+
+
+def _default_anthropic(monkeypatch):
+    from langstage_jupyter import config
+
+    monkeypatch.setattr(config, "AGENT_SPEC", None, raising=False)  # bundled default agent
+    monkeypatch.setattr(config, "MODEL_NAME", "anthropic:claude-sonnet-4-6", raising=False)
+
+
+def test_default_agent_without_key_is_needs_setup(monkeypatch):
+    _default_anthropic(monkeypatch)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    _use_agent(monkeypatch, _RunnableGraph())
+
+    status, ready, message = handlers._agent_readiness()
+    assert status == "needs_setup"
+    assert ready is False
+    assert "ANTHROPIC_API_KEY" in message
+
+
+def test_default_agent_with_key_is_healthy(monkeypatch):
+    _default_anthropic(monkeypatch)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    _use_agent(monkeypatch, _RunnableGraph())
+
+    status, ready, _ = handlers._agent_readiness()
+    assert status == "healthy" and ready is True
+
+
+def test_uncompiled_graph_is_not_runnable(monkeypatch):
+    _default_anthropic(monkeypatch)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")  # key present, but graph unrunnable
+    _use_agent(monkeypatch, _Uncompiled())
+
+    status, ready, message = handlers._agent_readiness()
+    assert status == "not_runnable" and ready is False
+    assert "runnable" in message.lower()
+
+
+def test_custom_agent_skips_the_default_key_check(monkeypatch):
+    # A BYO agent's credentials are the operator's concern — no default-key preflight.
+    from langstage_jupyter import config
+
+    monkeypatch.setattr(config, "AGENT_SPEC", "my_agent.py:graph", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    _use_agent(monkeypatch, _RunnableGraph())
+
+    status, ready, _ = handlers._agent_readiness()
+    assert status == "healthy" and ready is True
+
+
+def test_not_loaded_reports_agent_not_loaded(monkeypatch):
+    _use_agent(monkeypatch, None)
+    status, ready, _ = handlers._agent_readiness()
+    assert status == "agent_not_loaded" and ready is False


### PR DESCRIPTION
Closes #60 (nightly dogfood). The in-app counterpart to the family's `--verify` / `--serve-check` preflights.

Following the Quick Start **minus the API key** (a common first-run slip), the sidebar lit
🟢 "Agent is ready", but the first chat turn failed with a raw provider auth error. Root
cause: `HealthHandler` reported readiness as `agent.agent is not None`, and the default
agent's model is built lazily via `init_chat_model(...)` — it constructs fine with no key
and only fails at the first API call. "loaded" ≠ "can run a turn".

**Fix:**
- **Backend (`handlers.py`)** — `/health` now returns a `ready` flag gated on: the agent is
  a *runnable* graph (`callable(astream)` — also catches an uncompiled `StateGraph`, cf.
  langstage #69) **and**, for the **bundled default agent**, a cheap provider-key preflight
  (derive the provider from the model spec, check its standard env var). `agent_loaded`
  stays accurate for back-compat. A custom/BYO agent's credentials are the operator's concern.
- **Frontend (`widget.tsx` + CSS)** — the indicator keys off `ready`, adding a distinct 🟠
  `needs_setup` state with an actionable tooltip ("…ANTHROPIC_API_KEY is not set — the first
  turn will fail…") instead of a misleading green.

Tests cover no-key → `needs_setup`, with-key → `healthy`, uncompiled → `not_runnable`,
BYO-skips-the-default-check, and not-loaded. The Galata ui-tests drive a custom stub spec
(so the default-key preflight is skipped) and still reach green. Ships as **0.6.9**.