### PR TITLE
fix: propagate JupyterLab's exit code from the launcher (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.10 - 2026-07-08
+
+### Fixed
+- **The launcher now propagates JupyterLab's exit code (gh #62).** `langstage-jupyter` ran
+  `jupyter lab` via `subprocess.run(...)` but discarded the return code, so a startup
+  failure (port in use, a fatal config error, the root guard) still exited **0** — masking
+  the failure from `set -e`, CI steps, systemd, healthchecks, and `langstage-jupyter && …`.
+  It now exits with the child's return code.
+
 ## 0.6.9 - 2026-07-07
 
 ### Fixed

--- a/langstage_jupyter/launcher.py
+++ b/langstage_jupyter/launcher.py
@@ -471,7 +471,11 @@ def main():
     # Launch Jupyter Lab
     print(f"Launching: {' '.join(jupyter_args)}\n")
     try:
-        subprocess.run(jupyter_args, env=os.environ)
+        # Propagate JupyterLab's exit code — otherwise a startup failure (port in use,
+        # a fatal config error, the root guard) exits the launcher 0, so `set -e`, CI
+        # steps, systemd, and `langstage-jupyter && next` all think it succeeded (gh #62).
+        result = subprocess.run(jupyter_args, env=os.environ)
+        sys.exit(result.returncode)
     except KeyboardInterrupt:
         print("\n\nShutting down DeepAgent Lab...")
         sys.exit(0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -45,18 +45,22 @@ class TestExtractAgentArgs:
 class TestMainAgentWiring:
     """main() wires the agent flags into DEEPAGENT_AGENT_SPEC."""
 
-    def _run_main(self, argv, monkeypatch):
+    def _run_main(self, argv, monkeypatch, returncode=0):
         calls = {}
 
         def fake_run(cmd, env=None):
             calls["cmd"] = cmd
             calls["env_spec"] = (env or {}).get("LANGSTAGE_AGENT_SPEC")
+            return MagicMock(returncode=returncode)
 
         monkeypatch.setattr("langstage_jupyter.launcher.subprocess.run", fake_run)
         monkeypatch.setattr("sys.argv", ["langstage-jupyter"] + argv)
         monkeypatch.delenv("LANGSTAGE_AGENT_SPEC", raising=False)
         monkeypatch.delenv("DEEPAGENT_AGENT_SPEC", raising=False)
-        main()
+        # main() now propagates JupyterLab's exit code via sys.exit (gh #62).
+        with pytest.raises(SystemExit) as exc:
+            main()
+        calls["exit_code"] = exc.value.code
         return calls
 
     def test_demo_sets_stub_spec(self, monkeypatch):
@@ -70,6 +74,16 @@ class TestMainAgentWiring:
         assert calls["env_spec"] == "my.py:graph"
         assert "-a" not in calls["cmd"]
         assert "my.py:graph" not in calls["cmd"]
+
+    def test_launcher_propagates_jupyterlab_exit_code(self, monkeypatch):
+        # gh #62: a JupyterLab startup failure (port in use, root guard, bad config)
+        # exits non-zero, but the launcher discarded returncode and exited 0 — masking
+        # failures from set -e / CI / systemd. It must now surface the child's code.
+        calls = self._run_main(["--no-browser"], monkeypatch, returncode=1)
+        assert calls["exit_code"] == 1
+        # ...and a clean exit still propagates 0.
+        calls = self._run_main(["--no-browser"], monkeypatch, returncode=0)
+        assert calls["exit_code"] == 0
 
     def test_demo_and_agent_conflict(self, monkeypatch):
         monkeypatch.setattr("sys.argv", ["langstage-jupyter", "--demo", "-a", "x.py:g"])
@@ -269,10 +283,12 @@ class TestPortHandling:
 
         def fake_run(cmd, env=None):
             calls["cmd"] = cmd
+            return MagicMock(returncode=0)
 
         monkeypatch.setattr("langstage_jupyter.launcher.subprocess.run", fake_run)
         monkeypatch.setattr("sys.argv", ["langstage-jupyter"] + argv)
-        main()
+        with pytest.raises(SystemExit):  # main() propagates the child's exit code (gh #62)
+            main()
         return calls
 
     @pytest.mark.parametrize("bad", ["--port=", "--port=notaport"])


### PR DESCRIPTION
Closes #62 (nightly dogfood).

The `langstage-jupyter` launcher runs `jupyter lab` via `subprocess.run(...)` but never
inspected the child's return code — `main()` returned `None`, so the process exited **0**
regardless of how JupyterLab exited. When the server fails to start (port in use, a fatal
config error, running as root without `--allow-root`, …) it exits non-zero, but the launcher
reported success — silently masking the failure from any `set -e` script, CI step, systemd
unit, healthcheck, or `langstage-jupyter … && next` chain.

**Fix:** capture `subprocess.run(...).returncode` and `sys.exit()` with it. A clean exit
still returns 0; a failed start now surfaces the real non-zero code.

Python-only (launcher). Tests updated to assert the code is propagated (0 and non-zero).
Ships as **0.6.10**.