### PR TITLE
Inject --allow-root on the headline launch when running as root (gh #64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.11 - 2026-07-09
+
+### Fixed
+- **The headline `langstage-jupyter` launcher died immediately when run as root (gh #64).**
+  jupyter_server refuses to boot as root without `--allow-root`, so the primary zero-config
+  command exited `1` (after the extension loaded) on the `jupyter/*` Docker images, Binder,
+  CI runners, K8s notebook pods, and devcontainers — the exact root environments
+  `--serve-check` was hardened for (gh #58). The launch path now mirrors that treatment:
+  when `os.geteuid() == 0` and the user hasn't already passed it, it injects `--allow-root`
+  (same rationale as #58 — a token-gated, localhost server). A non-root laptop is unchanged,
+  and an explicit user `--allow-root` isn't duplicated.
+
 ## 0.6.10 - 2026-07-08
 
 ### Fixed

--- a/langstage_jupyter/launcher.py
+++ b/langstage_jupyter/launcher.py
@@ -468,6 +468,20 @@ def main():
     # Add any user-provided arguments
     jupyter_args.extend(args)
 
+    # The jupyter/* Docker images, Binder, CI runners, K8s notebook pods, and
+    # devcontainers all run as root, and jupyter_server refuses to boot as root
+    # without --allow-root — so the headline `langstage-jupyter` launch died
+    # immediately (exit 1, after the extension loaded) in exactly the environments
+    # --serve-check was hardened for (gh #58). Mirror that treatment on the real launch
+    # path (gh #64): inject --allow-root when we're root and the user hasn't already
+    # passed it. Same rationale as #58 — a token-gated, localhost server.
+    if (
+        hasattr(os, 'geteuid')
+        and os.geteuid() == 0
+        and not any(a == '--allow-root' or a.startswith('--ServerApp.allow_root') for a in args)
+    ):
+        jupyter_args.append('--allow-root')
+
     # Launch Jupyter Lab
     print(f"Launching: {' '.join(jupyter_args)}\n")
     try:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -90,6 +90,28 @@ class TestMainAgentWiring:
         with pytest.raises(SystemExit):
             main()
 
+    def test_injects_allow_root_when_running_as_root(self, monkeypatch):
+        # gh #64: the jupyter/* Docker images, Binder, CI, K8s, and devcontainers all run
+        # as root, and jupyter_server refuses to boot as root without --allow-root — so
+        # the headline launch died (exit 1) in exactly the environments --serve-check (#58)
+        # was hardened for. main() must inject --allow-root when euid == 0.
+        monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
+        calls = self._run_main(["--no-browser"], monkeypatch)
+        assert "--allow-root" in calls["cmd"]
+
+    def test_no_allow_root_when_not_root(self, monkeypatch):
+        # A non-root laptop must NOT get --allow-root injected (jupyter would warn/refuse
+        # differently, and there's no reason to relax the guard off-root).
+        monkeypatch.setattr(os, "geteuid", lambda: 1000, raising=False)
+        calls = self._run_main(["--no-browser"], monkeypatch)
+        assert "--allow-root" not in calls["cmd"]
+
+    def test_allow_root_not_duplicated_when_user_passed_it(self, monkeypatch):
+        # If the user already passed --allow-root, don't add a second one.
+        monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
+        calls = self._run_main(["--no-browser", "--allow-root"], monkeypatch)
+        assert calls["cmd"].count("--allow-root") == 1
+
 
 class TestLauncherHelpAndShowConfig:
     """--help shows the launcher's own flags; --show-config reflects -a/--demo."""


### PR DESCRIPTION
## What

The README's headline, zero-config command — `langstage-jupyter` — **failed to boot when run as root**, exiting `1` after the server extension had already loaded:

```
[I ServerApp] langstage_jupyter | extension was successfully loaded.
[C ServerApp] Running as root is not recommended. Use --allow-root to bypass.
exit=1
```

Root isn't an edge case here: the `jupyter/*` Docker images, Binder, most K8s/cloud notebook deployments, devcontainers, and CI runners all run as root. The package already treats "CI and Docker run as root" as a first-class target — `--serve-check` injects `--ServerApp.allow_root=True` for exactly this reason (gh #58). But the actual launch path never got the same treatment, so the primary user-facing command was broken in the very environments the preflight was hardened for. (gh #62, propagating the child exit code, is what surfaced this cleanly rather than as a masked success.)

### Asymmetry (the smoking gun)

| Command | Result (as root) |
|---|---|
| `langstage-jupyter --demo --no-browser` (headline) | **exit 1**, never boots |
| `langstage-jupyter --demo --serve-check` (preflight) | **exit 0**, verified |

## Fix

`main()` mirrors the `serve_check()` treatment — when `os.geteuid() == 0` and the user hasn't already passed it, inject `--allow-root`:

```python
if hasattr(os, "geteuid") and os.geteuid() == 0 and not any(
    a == "--allow-root" or a.startswith("--ServerApp.allow_root") for a in args
):
    jupyter_args.append("--allow-root")
```

Same safety rationale as #58 — a token-gated, localhost-only server. A non-root laptop is unaffected; an explicit user `--allow-root` isn't duplicated.

## Tests

`tests/test_launcher.py`: euid 0 → `--allow-root` injected; non-root → not injected; user already passed it → not duplicated.

Closes #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)