### PR TITLE
Preflight consistency: --verify names the missing key; add --check-connection for the manual-config path (Closes #66, #67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.6.13 - 2026-07-12
+
+### Added
+- **`langstage-jupyter --check-connection` — a preflight for the MANUAL-config path (gh #67).**
+  The README's "Alternative: Manual Configuration" flow hands you two values that must match
+  JupyterLab's startup parameters (`LANGSTAGE_JUPYTER_SERVER_URL`, `LANGSTAGE_JUPYTER_TOKEN`),
+  but nothing confirmed they actually reach a running server — a typo, wrong port, or stale
+  token loaded fine and only surfaced mid-chat when a notebook tool call silently failed to
+  authenticate. The existing preflights don't cover it: `--verify` runs the agent in-process
+  and never opens an HTTP connection, and `--serve-check` boots its *own* ephemeral server with
+  a *freshly generated* token. `--check-connection` resolves the configured URL+token through
+  the normal config chain and GETs `{server_url}/api/status` (an authenticated endpoint, so it
+  actually exercises the token), printing a one-line verdict and exiting `0`/`1`. It names the
+  distinct failure modes — server **unreachable** vs. token **rejected (403)** — and reports the
+  Jupyter Server version on success. `--check-server` is an alias. Completes the preflight family
+  (`--verify` / `--serve-check` / `--check-connection`), closing the last "documented surface
+  with no verifier" gap.
+
 ## 0.6.12 - 2026-07-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.6.12 - 2026-07-12
+
+### Fixed
+- **`--verify` on the bundled default agent with no `ANTHROPIC_API_KEY` now names the
+  missing variable instead of dumping a raw provider `TypeError` (gh #66).** The README
+  advertises `--verify` as the preflight that "catches a bad API key"; but the default
+  agent's model is built lazily, so a missing key didn't fail until the first API call —
+  and `core.verify()` (provider-agnostic) surfaced it as `TypeError: Could not resolve
+  authentication method...`, which never mentions the key. The launcher already knows this
+  branch is the default agent, so `--verify` now does the same cheap credential preflight
+  `/health` does (gh #60) *before* building it, short-circuiting with `ANTHROPIC_API_KEY is
+  not set — the default agent's first turn would fail. Set it and re-run.` The two
+  preflights (`--verify` and the sidebar/`/health`) now say the same thing about the same
+  failure. A custom/BYO agent (`-a`/spec) is unchanged — its credentials stay the
+  operator's concern and it keeps the full one-real-turn check. Shares the provider-key
+  lookup with `/health` via a new `handlers._missing_provider_key(model_name)` helper.
+
 ## 0.6.11 - 2026-07-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -100,13 +100,14 @@ langstage-jupyter --demo
 langstage-jupyter --show-config
 ```
 
-### Preflight checks (`--verify`, `--serve-check`)
+### Preflight checks (`--verify`, `--serve-check`, `--check-connection`)
 
-Two headless, no-browser preflights that exit `0`/`1` — handy in CI or before a deploy:
+Three headless, no-browser preflights that exit `0`/`1` — handy in CI or before a deploy:
 
 ```bash
 # Preflight the AGENT OBJECT: load the configured (or --demo) agent and run one real
-# turn through it. Catches a bad API key / broken tool / non-runnable graph.
+# turn through it. Catches a bad API key / broken tool / non-runnable graph. (For the
+# default agent with no key it now names the missing variable, e.g. ANTHROPIC_API_KEY.)
 langstage-jupyter --verify
 
 # Preflight the SERVED ENDPOINT: boot the server extension, poll /langstage-jupyter/health
@@ -115,7 +116,29 @@ langstage-jupyter --verify
 # (it never touches HTTP). Defaults to the keyless demo agent; add -a to test a real one.
 langstage-jupyter --serve-check
 langstage-jupyter -a my_agent.py:graph --serve-check
+
+# Preflight the MANUAL-CONFIG CONNECTION: confirm the configured
+# LANGSTAGE_JUPYTER_SERVER_URL + LANGSTAGE_JUPYTER_TOKEN actually reach a running,
+# auth-matching Jupyter (GET {url}/api/status with the token). Only meaningful for the
+# manual-config flow below — the launcher auto-manages these values. (--check-server alias.)
+langstage-jupyter --check-connection
 ```
+
+`--check-connection` names the distinct failure modes:
+
+```console
+$ langstage-jupyter --check-connection
+[ ok ] reached http://localhost:8888 — token accepted (Jupyter Server 2.20.0)
+
+# wrong port / server not up:
+[fail] http://localhost:8888 unreachable — is a Jupyter server running there? ...
+
+# URL right, token wrong (a stale token, a drifted --IdentityProvider.token):
+[fail] http://localhost:8888 returned 403 — LANGSTAGE_JUPYTER_TOKEN does not match ...
+```
+
+Unlike `--serve-check` (which boots its *own* ephemeral server with a *fresh* token),
+`--check-connection` tests your *configured* URL+token against an *already-running* server.
 
 The extension serves its REST/SSE routes under `/<base_url>langstage-jupyter/`:
 `health` (GET), `chat` (POST, SSE), `resume` (POST, SSE), `reload` (POST), `cancel` (POST).
@@ -142,6 +165,15 @@ jupyter lab --port 8888 --IdentityProvider.token=$LANGSTAGE_JUPYTER_TOKEN
 ```
 
 **Important:** The server URL and token must match between your environment variables and JupyterLab's startup parameters.
+
+Verify they do — before you start chatting — with the connection preflight:
+
+```bash
+langstage-jupyter --check-connection
+# [ ok ] reached http://localhost:8888 — token accepted (Jupyter Server 2.20.0)
+```
+
+It exits `0` when the configured `LANGSTAGE_JUPYTER_SERVER_URL` + `LANGSTAGE_JUPYTER_TOKEN` reach a running, auth-matching Jupyter, and `1` (naming the reason) when the server is unreachable or the token is rejected.
 
 ## Using Custom Agents
 

--- a/langstage_jupyter/handlers.py
+++ b/langstage_jupyter/handlers.py
@@ -41,6 +41,22 @@ _PROVIDER_KEY_ENV = {
 }
 
 
+def _missing_provider_key(model_name: str) -> Optional[str]:
+    """The provider key ``model_name`` needs, if it is absent from the environment.
+
+    Pure over ``model_name`` (the provider is the part before ``:``). Shared by the
+    ``/health`` default-agent readiness check and the launcher's ``--verify`` preflight
+    so both surfaces name the *same* variable for the same failure, instead of one dumping
+    a raw provider auth error (gh #60, gh #66). Returns ``None`` when the provider is
+    unknown or the key is already set.
+    """
+    provider = model_name.split(":", 1)[0].lower() if ":" in model_name else ""
+    env_var = _PROVIDER_KEY_ENV.get(provider)
+    if env_var and not os.environ.get(env_var):
+        return env_var
+    return None
+
+
 def _missing_default_agent_key() -> Optional[str]:
     """The provider key the BUNDLED default agent needs, if it is absent.
 
@@ -55,12 +71,7 @@ def _missing_default_agent_key() -> Optional[str]:
 
     if config.AGENT_SPEC:  # a custom agent was configured -> not our concern
         return None
-    model_name = (getattr(config, "MODEL_NAME", "") or "").strip()
-    provider = model_name.split(":", 1)[0].lower() if ":" in model_name else ""
-    env_var = _PROVIDER_KEY_ENV.get(provider)
-    if env_var and not os.environ.get(env_var):
-        return env_var
-    return None
+    return _missing_provider_key((getattr(config, "MODEL_NAME", "") or "").strip())
 
 
 def _agent_readiness():

--- a/langstage_jupyter/launcher.py
+++ b/langstage_jupyter/launcher.py
@@ -356,7 +356,27 @@ def main():
         from langstage_core.agui import verify as _core_verify
         from langstage_jupyter.config import LabConfig
 
-        spec = str(LabConfig.resolve().agent_spec or "").strip()
+        cfg = LabConfig.resolve()
+        spec = str(cfg.agent_spec or "").strip()
+
+        # For the BUNDLED default agent (no explicit spec), do the same cheap credential
+        # preflight /health does (gh #60) BEFORE building the agent. The model is built
+        # lazily, so a missing provider key doesn't fail until the first API call — so
+        # core.verify() surfaces it as a raw provider TypeError that never names the
+        # variable. Name it here instead, so --verify and /health say the same thing about
+        # the same failure. A custom/BYO agent's credentials stay the operator's concern
+        # (matching /health scoping) and keep the full one-real-turn check below. (gh #66)
+        if not spec:
+            from langstage_jupyter import handlers
+
+            missing = handlers._missing_provider_key(str(cfg.model_name or "").strip())
+            if missing:
+                print(
+                    f"[fail] agent verification failed: {missing} is not set — the default "
+                    "agent's first turn would fail. Set it and re-run."
+                )
+                sys.exit(1)
+
         try:
             if spec:
                 from langstage_core import load_agent_spec

--- a/langstage_jupyter/launcher.py
+++ b/langstage_jupyter/launcher.py
@@ -39,6 +39,8 @@ Launcher options:
   --verify           Preflight the agent (run one real turn); exit 0/1. Then exit.
   --serve-check      Headless HTTP smoke test: boot the server extension, serve one
                      turn over /langstage-jupyter/chat, exit 0/1. Then exit.
+  --check-connection Manual-config preflight: verify LANGSTAGE_JUPYTER_SERVER_URL +
+                     LANGSTAGE_JUPYTER_TOKEN reach a running Jupyter; exit 0/1. Then exit.
   --version, -V      Print the langstage-jupyter version and exit.
   -h, --help         Show this message and exit.
 
@@ -288,6 +290,108 @@ def serve_check(agent_spec=None, *, boot_timeout=45.0, turn_timeout=60.0):
             proc.kill()
 
 
+# ── --check-connection: preflight the MANUAL-config Jupyter connection (gh #67) ──
+#
+# The one documented surface with no verifier. The README's "Alternative: Manual
+# Configuration" path hands the user two values they must get exactly right and warns
+# in bold that they "must match" JupyterLab's startup parameters — but nothing confirms
+# they actually reach a running, auth-matching server before the first chat. --verify
+# never opens an HTTP connection, and --serve-check boots its OWN server with a FRESH
+# token, so neither can catch a manual-config mismatch. This does.
+
+
+def _connection_verdict(server_url, *, status=None, server_version=None,
+                        unreachable=False, error=None):
+    """Reduce a ``/api/status`` probe to ``(exit_code, message)``.
+
+    Pure so the verdict logic is unit-testable without a live Jupyter (mirrors
+    ``_summarize_sse`` for ``--serve-check``). Exactly one outcome is supplied:
+
+    * ``unreachable=True`` — connection refused / DNS failure / timeout,
+    * ``status=<int>``     — the HTTP status ``/api/status`` returned (it is
+      ``@web.authenticated``, so a wrong/missing token yields 403),
+    * ``error=<str>``      — some other client-side failure.
+
+    Names the two distinct failure modes the enhancement is about — server
+    *unreachable* vs. token *rejected* — so triage is one glance, not a chat session.
+    """
+    if unreachable:
+        return 1, (
+            f"[fail] {server_url} unreachable — is a Jupyter server running there? "
+            "Check LANGSTAGE_JUPYTER_SERVER_URL and that `jupyter lab` is up."
+        )
+    if error is not None:
+        return 1, f"[fail] could not probe {server_url}: {error}"
+    if status in (401, 403):
+        return 1, (
+            f"[fail] {server_url} returned {status} — LANGSTAGE_JUPYTER_TOKEN does not match "
+            "the token JupyterLab was launched with (--IdentityProvider.token)."
+        )
+    if status == 200:
+        suffix = f" (Jupyter Server {server_version})" if server_version else ""
+        return 0, f"[ ok ] reached {server_url} — token accepted{suffix}"
+    return 1, f"[fail] {server_url} returned unexpected HTTP {status}"
+
+
+def check_connection(*, timeout=5.0):
+    """Confirm the configured URL+token reach a running, auth-matching Jupyter (gh #67).
+
+    Resolve ``LANGSTAGE_JUPYTER_SERVER_URL`` + ``LANGSTAGE_JUPYTER_TOKEN`` through the
+    normal config chain (env / ``langstage.toml``, canonical-wins) and GET
+    ``{server_url}/api/status`` with the token. ``/api/status`` is ``@web.authenticated``,
+    so this actually exercises the token — the load-bearing check the "must match"
+    invariant needs. Prints a one-line verdict and returns ``0``/``1``.
+
+    Unlike ``--serve-check`` (which boots its own ephemeral server with a freshly
+    generated token), this tests the user's *configured* values against an
+    *already-running* server — the manual-config mismatch the other preflights can't see.
+    """
+    import json
+    import urllib.error
+    import urllib.request
+
+    from langstage_jupyter.config import LabConfig
+
+    cfg = LabConfig.resolve()
+    server_url = str(cfg.jupyter_server_url or "").strip().rstrip("/")
+    token = str(cfg.jupyter_token or "").strip()
+
+    if not server_url:
+        print("[fail] LANGSTAGE_JUPYTER_SERVER_URL is not set — nothing to check.")
+        return 1
+
+    def _get(path):
+        req = urllib.request.Request(
+            f"{server_url}{path}",
+            headers={"Authorization": f"token {token}"} if token else {},
+        )
+        return urllib.request.urlopen(req, timeout=timeout)
+
+    try:
+        status = _get("/api/status").getcode()
+    except urllib.error.HTTPError as e:
+        code, message = _connection_verdict(server_url, status=e.code)
+        print(message)
+        return code
+    except (urllib.error.URLError, ConnectionError, OSError):
+        # Connection refused / DNS / timeout — the server isn't reachable at that URL.
+        code, message = _connection_verdict(server_url, unreachable=True)
+        print(message)
+        return code
+
+    # Token accepted. Best-effort: enrich the verdict with the server version from the
+    # unauthenticated /api endpoint (/api/status doesn't carry it). Never fail on this.
+    version = None
+    try:
+        version = json.loads(_get("/api").read()).get("version")
+    except Exception:  # noqa: BLE001 - version is cosmetic
+        pass
+
+    code, message = _connection_verdict(server_url, status=status, server_version=version)
+    print(message)
+    return code
+
+
 def main():
     """Main launcher function."""
     # Parse command line arguments
@@ -403,6 +507,13 @@ def main():
     # Defaults to the keyless demo agent (CI-safe); honors -a for a real agent.
     if "--serve-check" in args or "--smoke" in args:
         sys.exit(serve_check(agent_spec))
+
+    # --check-connection: the MANUAL-config connection preflight (gh #67). Confirm the
+    # configured LANGSTAGE_JUPYTER_SERVER_URL + LANGSTAGE_JUPYTER_TOKEN actually reach a
+    # running, auth-matching Jupyter — the one "must match" invariant with no verifier
+    # (--verify never opens HTTP; --serve-check boots its own server with a fresh token).
+    if "--check-connection" in args or "--check-server" in args:
+        sys.exit(check_connection())
 
     if agent_spec:
         print(f"Agent spec: {agent_spec}")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -7,7 +7,9 @@ import pytest
 from unittest.mock import Mock, patch, MagicMock
 from langstage_jupyter.launcher import (
     DEMO_AGENT_SPEC,
+    _connection_verdict,
     _summarize_sse,
+    check_connection,
     extract_agent_args,
     find_available_port,
     generate_token,
@@ -377,6 +379,16 @@ class TestVerifyFlag:
         monkeypatch.delenv("LANGSTAGE_MODEL_NAME", raising=False)
         monkeypatch.delenv("DEEPAGENT_MODEL_NAME", raising=False)
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-not-real")
+
+        # Stub the bundled default-agent module so the load path is hermetic — we're
+        # asserting the credential check falls through, not building the real model.
+        import sys
+        import types
+
+        fake_agent_mod = types.ModuleType("langstage_jupyter.agent")
+        fake_agent_mod.agent = object()  # sentinel graph handed to core.verify
+        monkeypatch.setitem(sys.modules, "langstage_jupyter.agent", fake_agent_mod)
+
         ran = {}
 
         class _Result:
@@ -384,7 +396,7 @@ class TestVerifyFlag:
             reason = "one turn completed cleanly"
 
         def fake_verify(graph, *a, **k):
-            ran["called"] = True
+            ran["graph"] = graph
             return _Result()
 
         monkeypatch.setattr("langstage_core.agui.verify", fake_verify)
@@ -392,7 +404,7 @@ class TestVerifyFlag:
         with pytest.raises(SystemExit) as exc:
             main()
         assert exc.value.code == 0
-        assert ran.get("called") is True  # the real turn WAS attempted
+        assert ran.get("graph") is fake_agent_mod.agent  # got PAST the key check to the turn
         assert "agent verified" in capsys.readouterr().out
 
     def test_verify_broken_agent_fails_exit_one(self, monkeypatch, capsys, tmp_path):
@@ -557,3 +569,168 @@ class TestServeCheckServerSpawn:
 def test_serve_check_end_to_end_with_demo_agent():
     """The real thing: boot the server extension headlessly and serve one turn."""
     assert serve_check(DEMO_AGENT_SPEC) == 0
+
+
+class TestConnectionVerdict:
+    """_connection_verdict reduces a /api/status probe to (exit_code, message) — the
+    verdict logic behind --check-connection, unit-tested without a server (gh #67)."""
+
+    def test_ok_with_version(self):
+        code, msg = _connection_verdict("http://localhost:8888", status=200, server_version="2.20.0")
+        assert code == 0
+        assert msg.startswith("[ ok ]")
+        assert "token accepted" in msg
+        assert "2.20.0" in msg
+
+    def test_ok_without_version_omits_suffix(self):
+        code, msg = _connection_verdict("http://localhost:8888", status=200)
+        assert code == 0 and "token accepted" in msg
+        assert "Jupyter Server" not in msg  # no dangling empty parens
+
+    @pytest.mark.parametrize("status", [401, 403])
+    def test_auth_failure_names_the_token_var(self, status):
+        # URL right, token wrong — the distinct failure mode this enhancement is about.
+        code, msg = _connection_verdict("http://localhost:8888", status=status)
+        assert code == 1
+        assert str(status) in msg
+        assert "LANGSTAGE_JUPYTER_TOKEN" in msg
+        assert "IdentityProvider.token" in msg
+
+    def test_unreachable_names_the_url_and_server(self):
+        code, msg = _connection_verdict("http://localhost:8888", unreachable=True)
+        assert code == 1
+        assert "unreachable" in msg
+        assert "LANGSTAGE_JUPYTER_SERVER_URL" in msg
+
+    def test_unexpected_status_fails(self):
+        code, msg = _connection_verdict("http://localhost:8888", status=500)
+        assert code == 1 and "500" in msg
+
+    def test_client_error_is_reported(self):
+        code, msg = _connection_verdict("http://localhost:8888", error="boom")
+        assert code == 1 and "boom" in msg
+
+
+class _FakeResp:
+    def __init__(self, code, body=b"{}"):
+        self._code = code
+        self._body = body
+
+    def getcode(self):
+        return self._code
+
+    def read(self):
+        return self._body
+
+
+class TestCheckConnection:
+    """check_connection() resolves the configured URL+token and probes /api/status,
+    naming the distinct reachable/auth failure modes (gh #67)."""
+
+    def _configure(self, monkeypatch, url="http://localhost:8888", token="tok"):
+        monkeypatch.setenv("LANGSTAGE_JUPYTER_SERVER_URL", url)
+        monkeypatch.setenv("LANGSTAGE_JUPYTER_TOKEN", token)
+
+    def test_token_accepted_returns_zero_with_version(self, monkeypatch, capsys):
+        self._configure(monkeypatch)
+        import urllib.request
+
+        def fake_urlopen(req, timeout=None):
+            if req.full_url.endswith("/api/status"):
+                # the token actually reaches an authenticated endpoint
+                assert req.get_header("Authorization") == "token tok"
+                return _FakeResp(200)
+            return _FakeResp(200, b'{"version": "2.20.0"}')  # /api version enrichment
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        assert check_connection() == 0
+        out = capsys.readouterr().out
+        assert "[ ok ]" in out and "2.20.0" in out
+
+    def test_wrong_token_returns_403(self, monkeypatch, capsys):
+        self._configure(monkeypatch, token="wrong")
+        import urllib.error
+        import urllib.request
+
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.HTTPError(req.full_url, 403, "Forbidden", {}, None)
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        assert check_connection() == 1
+        out = capsys.readouterr().out
+        assert "403" in out and "LANGSTAGE_JUPYTER_TOKEN" in out
+
+    def test_unreachable_returns_one(self, monkeypatch, capsys):
+        self._configure(monkeypatch)
+        import urllib.error
+        import urllib.request
+
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.URLError("Connection refused")
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        assert check_connection() == 1
+        assert "unreachable" in capsys.readouterr().out
+
+    def test_version_enrichment_failure_never_fails_the_check(self, monkeypatch, capsys):
+        # The optional /api version fetch must not turn a token-accepted result into a fail.
+        self._configure(monkeypatch)
+        import urllib.error
+        import urllib.request
+
+        def fake_urlopen(req, timeout=None):
+            if req.full_url.endswith("/api/status"):
+                return _FakeResp(200)
+            raise urllib.error.URLError("no /api")  # version enrichment blows up
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        assert check_connection() == 0
+        out = capsys.readouterr().out
+        assert "[ ok ]" in out and "Jupyter Server" not in out
+
+    def test_missing_server_url_fails_fast(self, monkeypatch, capsys):
+        # An empty URL can't be checked — name the var rather than throwing.
+        monkeypatch.setenv("LANGSTAGE_JUPYTER_SERVER_URL", "")
+        monkeypatch.setenv("DEEPAGENT_JUPYTER_SERVER_URL", "")
+        # LabConfig has a non-empty default jupyter_server_url, so force the resolved value
+        # empty to exercise the guard.
+        from langstage_jupyter import config as _config
+
+        class _Cfg:
+            jupyter_server_url = ""
+            jupyter_token = "tok"
+
+        monkeypatch.setattr(_config.LabConfig, "resolve", classmethod(lambda cls, *a, **k: _Cfg()))
+        assert check_connection() == 1
+        assert "LANGSTAGE_JUPYTER_SERVER_URL is not set" in capsys.readouterr().out
+
+
+class TestCheckConnectionRouting:
+    """main() routes --check-connection / --check-server to check_connection() (gh #67)."""
+
+    @pytest.mark.parametrize("flag", ["--check-connection", "--check-server"])
+    def test_flag_calls_check_connection_and_exits_with_its_code(self, flag, monkeypatch):
+        called = {}
+
+        def fake_check(**kw):
+            called["hit"] = True
+            return 0
+
+        monkeypatch.setattr("langstage_jupyter.launcher.check_connection", fake_check)
+        monkeypatch.setattr("sys.argv", ["langstage-jupyter", flag])
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 0
+        assert called.get("hit") is True  # routed here, not to jupyter lab
+
+    def test_nonzero_code_propagates(self, monkeypatch):
+        monkeypatch.setattr("langstage_jupyter.launcher.check_connection", lambda **kw: 1)
+        monkeypatch.setattr("sys.argv", ["langstage-jupyter", "--check-connection"])
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 1
+
+    def test_help_lists_check_connection(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["langstage-jupyter", "--help"])
+        main()
+        assert "--check-connection" in capsys.readouterr().out

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -344,6 +344,57 @@ class TestVerifyFlag:
         assert exc.value.code == 0
         assert "agent verified" in capsys.readouterr().out
 
+    def test_verify_default_agent_missing_key_names_the_variable(self, monkeypatch, capsys):
+        # gh #66: with the BUNDLED default agent and no ANTHROPIC_API_KEY, --verify must
+        # name the missing variable — the same actionable message /health gives (gh #60) —
+        # instead of dumping a raw provider `TypeError: Could not resolve authentication
+        # method...`. It short-circuits BEFORE building the agent / calling core.verify.
+        monkeypatch.setenv("LANGSTAGE_AGENT_SPEC", "")  # default agent (no explicit spec)
+        monkeypatch.setenv("DEEPAGENT_AGENT_SPEC", "")
+        monkeypatch.delenv("LANGSTAGE_MODEL_NAME", raising=False)  # default anthropic model
+        monkeypatch.delenv("DEEPAGENT_MODEL_NAME", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        # If the short-circuit regressed, core.verify() would run a real turn — make that a
+        # hard failure rather than a slow/networked pass.
+        monkeypatch.setattr(
+            "langstage_core.agui.verify",
+            lambda *a, **k: pytest.fail("core.verify must not run when the default key is missing"),
+        )
+        monkeypatch.setattr("sys.argv", ["langstage-jupyter", "--verify"])
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "ANTHROPIC_API_KEY" in out       # names the exact variable...
+        assert "verification failed" in out     # ...as a verify verdict...
+        assert "TypeError" not in out           # ...not a raw provider stack string (gh #66)
+
+    def test_verify_default_agent_with_key_still_runs_the_real_turn(self, monkeypatch, capsys):
+        # The credential short-circuit is scoped to a MISSING key: when the key is present,
+        # --verify must fall through to the real one-turn check (core.verify), not skip it.
+        monkeypatch.setenv("LANGSTAGE_AGENT_SPEC", "")
+        monkeypatch.setenv("DEEPAGENT_AGENT_SPEC", "")
+        monkeypatch.delenv("LANGSTAGE_MODEL_NAME", raising=False)
+        monkeypatch.delenv("DEEPAGENT_MODEL_NAME", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-not-real")
+        ran = {}
+
+        class _Result:
+            ok = True
+            reason = "one turn completed cleanly"
+
+        def fake_verify(graph, *a, **k):
+            ran["called"] = True
+            return _Result()
+
+        monkeypatch.setattr("langstage_core.agui.verify", fake_verify)
+        monkeypatch.setattr("sys.argv", ["langstage-jupyter", "--verify"])
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 0
+        assert ran.get("called") is True  # the real turn WAS attempted
+        assert "agent verified" in capsys.readouterr().out
+
     def test_verify_broken_agent_fails_exit_one(self, monkeypatch, capsys, tmp_path):
         agent = tmp_path / "broken.py"
         agent.write_text(


### PR DESCRIPTION
Two commits, one per issue — completing the preflight family so every documented surface has a verifier that says the same thing.

## `Closes #66` — `--verify` names the missing provider key (0.6.12)

**Root cause.** The README advertises `--verify` as the preflight that "catches a bad API key", but for the **bundled default agent** with no `ANTHROPIC_API_KEY` it printed a raw provider stack string:

```
[fail] agent verification failed: TypeError: "Could not resolve authentication method. Expected one of api_key, auth_token, or credentials to be set..."
```

The default agent's model is built lazily, so a missing key doesn't fail until the first API call; `core.verify()` is provider-agnostic and can only report the resulting exception. This is inconsistent with `/health` (gh #60), which already names the variable for the *same* failure.

**Fix.** The launcher's `--verify` block already knows it's on the default-agent branch (empty spec), so it now runs the *same* cheap credential preflight `/health` does — **before** building the agent — and short-circuits with a message that names the exact variable:

```
[fail] agent verification failed: ANTHROPIC_API_KEY is not set — the default agent's first turn would fail. Set it and re-run.
```

A custom/BYO agent (`-a`/spec) is unchanged: its credentials stay the operator's concern and it keeps the full one-real-turn check. The provider-key lookup shared by both surfaces is extracted into `handlers._missing_provider_key(model_name)`; `_missing_default_agent_key()` delegates to it.

**Verified.** Reproduced the raw `TypeError` on `0.6.11`, confirmed the fix prints the key-naming message (exit 1). Added regression tests: default-agent-no-key names the variable and never reaches `core.verify()`; key-present still runs the real turn.

## `Closes #67` — `--check-connection`, a preflight for the manual-config path (0.6.13)

**Motivation.** The README's "Alternative: Manual Configuration" flow hands the user `LANGSTAGE_JUPYTER_SERVER_URL` + `LANGSTAGE_JUPYTER_TOKEN` and warns in bold they "must match" JupyterLab's startup parameters — but nothing confirmed they actually reach a running, auth-matching server. A typo, wrong port, or stale token loaded fine and only surfaced mid-chat when a notebook tool call silently failed to authenticate. `--verify` never opens HTTP; `--serve-check` boots its *own* server with a *fresh* token — so neither can catch a manual-config mismatch.

**Implementation.** `langstage-jupyter --check-connection` resolves the configured URL+token through the normal config chain and GETs `{server_url}/api/status` — an authenticated endpoint (`@web.authenticated`), so it actually exercises the token — then prints a one-line verdict and exits `0`/`1`. It names the two distinct failure modes and reports the server version on success. `--check-server` is an alias.

```console
$ langstage-jupyter --check-connection
[ ok ] reached http://localhost:8888 — token accepted (Jupyter Server 2.20.0)

# wrong port / server down:
[fail] http://localhost:8888 unreachable — is a Jupyter server running there? ...

# URL right, token wrong:
[fail] http://localhost:8888 returned 403 — LANGSTAGE_JUPYTER_TOKEN does not match the token JupyterLab was launched with (--IdentityProvider.token).
```

**Verified.** Booted a real `jupyter_server` and exercised all three paths end-to-end (correct token → `0` with version; wrong token → `403`, exit `1`; unreachable → exit `1`), plus the `--check-server` alias. The verdict logic is factored into a pure `_connection_verdict()` unit-tested without a live server (mirroring `_summarize_sse`); `check_connection()` is covered for token-accepted, wrong-token, unreachable, version-enrichment-failure, and missing-URL; `main()` routing is covered for both flag spellings. README documents it in the preflight section and at the manual-config "must match" callout.

## Conventions

- One branch, one commit per issue; each bumps the patch version (`package.json`: 0.6.11 → 0.6.12 → 0.6.13) and adds a `CHANGELOG.md` entry, matching recent PRs. `_version.py` left as the build-generated artifact (recent version-bump PRs touch only `package.json`).
- Full suite green locally: **142 passed, 1 skipped** (was 124 passed at baseline; +18 new tests). No frontend/`src` changes, so Galata UI tests are unaffected; new top-level imports are all stdlib, so the `minimal-install` guard is unaffected; the `labext-version` guard rebuilds from the bumped `package.json`, so parity holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFhpZ6DJkyCM6sQB99uNY