### PR TITLE
Fix duplicate-token launcher crash (#69) + let the agent author markdown cells (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.6.16 - 2026-07-14
+
+### Fixed
+- **Pinning the auth token no longer crashes the launcher (gh #69).** The launcher
+  *unconditionally* injected its own `--IdentityProvider.token <auto>` before appending your
+  pass-through args, so passing a token yourself — `--IdentityProvider.token=...` (or the
+  `--ServerApp.token=` alias), a standard `jupyter lab` argument the README advertises as
+  supported and uses in its Manual-Config section — made jupyter_server see the token twice and
+  abort with `ValueError: token only accepts one value, got 2`, naming a value you never typed.
+  The server never came up. This was the untreated token twin of the already-fixed `--port`
+  duplicate (gh #40): the launcher now detects a user-supplied token, respects it (does **not**
+  inject its own), and wires that same value into `LANGSTAGE_JUPYTER_TOKEN` so the agent's
+  notebook tools authenticate against the server you launched. An explicitly empty
+  `--IdentityProvider.token=` (auth disabled) is honored too.
+
+### Added
+- **The agent can now author and edit markdown cells (gh #70).** The notebook toolset only ever
+  touched *code* cells — there was no way to insert a markdown cell, and `modify_cell` hard-refused
+  any non-code cell (`Error: Cell N is not a code cell`) — so the agent could write and run code
+  but could not add a title, a section header, or a paragraph of narrative, nor edit markdown the
+  user already wrote. The gap was silent and confusing because `get_notebook_state` **shows**
+  markdown cells to the agent, so the model would try to edit them and hit a dead end. Now:
+  - a new **`insert_markdown_cell(text, notebook_path, cell_index=-1)`** tool (the markdown twin of
+    `insert_code_cell`), registered in `NOTEBOOK_TOOLS` and documented in the agent's system prompt;
+  - **`modify_cell` now edits markdown cells too** — it replaces the source of code *and* markdown
+    cells (clearing outputs/execution count only for code). Its empty-string sentinel still refuses
+    to blank a cell, for markdown as well, pointing you at `delete_cell`.
+
 ## 0.6.15 - 2026-07-13
 
 ### Changed

--- a/langstage_jupyter/agent.py
+++ b/langstage_jupyter/agent.py
@@ -31,6 +31,7 @@ from langstage_jupyter.notebook_tools import (  # noqa: F401 - re-exported
     get_notebook_kernel_id,
     get_notebook_state,
     insert_code_cell,
+    insert_markdown_cell,
     kernel_clients,
     modify_cell,
     read_cell,
@@ -65,7 +66,8 @@ system_prompt = """You're a JupyterLab assistant. Use the provided tools to mani
 - `read_cell(notebook_path: str, cell_index: int) -> str`: The full source of one cell. Read a cell before modifying it instead of guessing its contents.
 - `create_notebook(notebook_path: str, overwrite: bool = False) -> str`: Creates a new EMPTY notebook. If the notebook already exists it is left untouched and nothing is overwritten — only pass overwrite=True when you deliberately want to destroy its existing cells.
 - `insert_code_cell(code: str, notebook_path: str, cell_index: int = -1) -> str`: Inserts a new code cell at `cell_index` (default -1 appends at the end).
-- `modify_cell(notebook_path: str, cell_index: int, new_code: str) -> str`: Replaces the code of the cell at `cell_index` (clearing its old outputs). It does NOT delete — use `delete_cell` for that.
+- `insert_markdown_cell(text: str, notebook_path: str, cell_index: int = -1) -> str`: Inserts a new markdown cell at `cell_index` (default -1 appends at the end) — use it for titles, section headers, and narrative prose. Markdown cells are NOT executed.
+- `modify_cell(notebook_path: str, cell_index: int, new_code: str) -> str`: Replaces the source of the cell at `cell_index` — works on both code and markdown cells (for a code cell it also clears the old outputs). It does NOT delete — use `delete_cell` for that.
 - `delete_cell(notebook_path: str, cell_index: int) -> str`: Deletes the cell at `cell_index`.
 - `execute_cell(notebook_path: str, cell_index: int = -1) -> str`: Executes the code cell at `cell_index` and stores its outputs. Returns the outputs or the error. Starts the notebook's kernel if needed.
 

--- a/langstage_jupyter/launcher.py
+++ b/langstage_jupyter/launcher.py
@@ -153,6 +153,31 @@ def generate_token():
     return secrets.token_urlsafe(32)
 
 
+#: The token arguments `jupyter lab` accepts. ``--IdentityProvider.token`` is the
+#: modern name; ``--ServerApp.token`` is the documented alias. If the user passes
+#: either, the launcher must not inject its own or the two collide (gh #69).
+TOKEN_ARG_NAMES = ("--IdentityProvider.token", "--ServerApp.token")
+
+
+def _find_user_token(args):
+    """Return the token the user pinned via a jupyter-lab token arg, else ``None``.
+
+    Mirrors the ``--port`` scan (gh #40): recognizes both the space form
+    (``--IdentityProvider.token TOK``) and the equals form
+    (``--IdentityProvider.token=TOK``) for either accepted name. An explicitly
+    empty value (``--IdentityProvider.token=``, i.e. auth disabled) is a real
+    user choice and is returned as ``""`` — distinct from ``None`` (not supplied),
+    so the launcher respects "no token" and still doesn't inject its own.
+    """
+    for i, arg in enumerate(args):
+        for name in TOKEN_ARG_NAMES:
+            if arg == name and i + 1 < len(args):
+                return args[i + 1]
+            if arg.startswith(name + "="):
+                return arg.split("=", 1)[1]
+    return None
+
+
 # ── --serve-check: headless HTTP smoke test of the deployed extension ──
 #
 # The served route prefix the extension registers (handlers.setup_handlers).
@@ -588,13 +613,28 @@ def main():
         port = find_available_port()
         print(f"Auto-detected available port: {port}")
 
-    # Generate token (or use existing if set)
-    token = os.getenv('JUPYTER_TOKEN')
-    if not token:
-        token = generate_token()
-        print("Generated secure authentication token")
+    # Check if the user pinned an auth token themselves. --IdentityProvider.token
+    # (and its --ServerApp.token alias) is a standard `jupyter lab` argument the
+    # README advertises as supported and uses in its Manual-Config section. If the
+    # user supplies it we must NOT also inject our own, or jupyter_server sees the
+    # token twice and aborts with "token only accepts one value, got 2" — the token
+    # twin of the #40 --port duplicate crash. Detect it, respect the user's value,
+    # and wire it through to the agent below. (gh #69)
+    user_token = _find_user_token(args)
+
+    # Resolve the auth token. Precedence: a user-pinned --IdentityProvider.token /
+    # --ServerApp.token (respected as-is and NOT re-injected — see below), then
+    # JUPYTER_TOKEN from the env, then a freshly generated secure token.
+    if user_token is not None:
+        token = user_token
+        print("Using user-specified token (--IdentityProvider.token/--ServerApp.token)")
     else:
-        print("Using existing JUPYTER_TOKEN from environment")
+        token = os.getenv('JUPYTER_TOKEN')
+        if not token:
+            token = generate_token()
+            print("Generated secure authentication token")
+        else:
+            print("Using existing JUPYTER_TOKEN from environment")
 
     # Determine server URL
     # Use localhost for security (only local connections)
@@ -628,8 +668,11 @@ def main():
     if user_port is None:
         jupyter_args.extend(['--port', str(port)])
 
-    # Add token
-    jupyter_args.extend(['--IdentityProvider.token', token])
+    # Inject our token only when the user didn't pin one themselves — otherwise
+    # jupyter_server sees the token twice and aborts (gh #69, the token twin of #40).
+    # The user's own --IdentityProvider.token/--ServerApp.token rides through in `args`.
+    if user_token is None:
+        jupyter_args.extend(['--IdentityProvider.token', token])
 
     # Add any user-provided arguments
     jupyter_args.extend(args)

--- a/langstage_jupyter/notebook_tools.py
+++ b/langstage_jupyter/notebook_tools.py
@@ -338,12 +338,49 @@ def insert_code_cell(
     return f"Inserted code cell at index {cell_index} in {notebook_path}"
 
 
+def insert_markdown_cell(
+    text: Annotated[str, "Markdown text for the cell"],
+    notebook_path: Annotated[str, "Notebook filename"],
+    cell_index: Annotated[int, "Index to insert at (-1 appends at the end)"] = -1,
+) -> str:
+    """Insert a new markdown cell into an existing notebook.
+
+    The markdown twin of :func:`insert_code_cell` — for titles, section headers,
+    and the narrative prose that a notebook interleaves with its code. Markdown
+    cells are never executed, so there's no execute step after inserting one.
+    """
+    notebook_path = _norm(notebook_path)
+    try:
+        nb = _load_notebook(notebook_path)
+    except NotebookNotFound:
+        return (
+            f"Error: Notebook not found at {notebook_path}. "
+            "Create it first with create_notebook."
+        )
+
+    new_cell = nbformat.v4.new_markdown_cell(source=text)
+    if cell_index == -1:
+        nb.cells.append(new_cell)
+        cell_index = len(nb.cells) - 1
+    else:
+        if cell_index < 0 or cell_index > len(nb.cells):
+            return f"Error: Cell index {cell_index} out of range (0-{len(nb.cells)})"
+        nb.cells.insert(cell_index, new_cell)
+
+    _save_notebook(nb, notebook_path)
+    return f"Inserted markdown cell at index {cell_index} in {notebook_path}"
+
+
 def modify_cell(
     notebook_path: Annotated[str, "Notebook filename"],
     cell_index: Annotated[int, "Index of cell to modify"],
-    new_code: Annotated[str, "New code for the cell"],
+    new_code: Annotated[str, "New source for the cell (code or markdown)"],
 ) -> str:
-    """Replace a code cell's source (clearing its stale outputs/execution count).
+    """Replace a cell's source. Works on **code and markdown** cells alike.
+
+    For a code cell, the stale outputs/execution count are cleared. A markdown
+    cell has neither, so only its source is replaced (this is how you edit a
+    title, header, or paragraph — gh #70).
 
     Does **not** delete: an empty ``new_code`` used to silently remove the cell.
     Use :func:`delete_cell` to remove one.
@@ -363,11 +400,13 @@ def modify_cell(
         return err
 
     cell = nb.cells[cell_index]
-    if cell.cell_type != "code":
-        return f"Error: Cell {cell_index} is not a code cell"
     cell.source = new_code
-    cell.outputs = []
-    cell.execution_count = None
+    # Only code cells carry outputs / an execution count to invalidate; a markdown
+    # cell has neither, so the old code-only guard was the only thing blocking a
+    # markdown edit (gh #70).
+    if cell.cell_type == "code":
+        cell.outputs = []
+        cell.execution_count = None
 
     _save_notebook(nb, notebook_path)
     return f"Modified cell at index {cell_index} in {notebook_path}"
@@ -481,6 +520,7 @@ NOTEBOOK_TOOLS = [
     read_cell,
     create_notebook,
     insert_code_cell,
+    insert_markdown_cell,
     modify_cell,
     delete_cell,
     execute_cell,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -334,6 +334,84 @@ class TestPortHandling:
         assert calls["cmd"].count("--port") == 1  # exactly one, auto-detected
 
 
+class TestTokenHandling:
+    """A user-supplied token must not be duplicated by our injected one (gh #69),
+    the untreated token twin of the #40 --port duplicate crash."""
+
+    def _run_main(self, argv, monkeypatch):
+        calls = {}
+
+        def fake_run(cmd, env=None):
+            calls["cmd"] = cmd
+            calls["env"] = dict(env or {})
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr("langstage_jupyter.launcher.subprocess.run", fake_run)
+        monkeypatch.setattr("sys.argv", ["langstage-jupyter"] + argv)
+        monkeypatch.delenv("JUPYTER_TOKEN", raising=False)
+        with pytest.raises(SystemExit):  # main() propagates the child's exit code (gh #62)
+            main()
+        return calls
+
+    def _token_value_count(self, cmd):
+        """How many times a token VALUE reaches jupyter lab — via either the
+        space form (`--IdentityProvider.token TOK`) or the equals form
+        (`--IdentityProvider.token=TOK` / `--ServerApp.token=TOK`)."""
+        names = ("--IdentityProvider.token", "--ServerApp.token")
+        n = 0
+        for i, a in enumerate(cmd):
+            if a in names and i + 1 < len(cmd):
+                n += 1
+            elif any(a.startswith(name + "=") for name in names):
+                n += 1
+        return n
+
+    def test_no_token_arg_auto_injects_one(self, monkeypatch):
+        # Baseline: with no user token, the launcher injects exactly one.
+        calls = self._run_main(["--no-browser"], monkeypatch)
+        assert self._token_value_count(calls["cmd"]) == 1
+        assert "--IdentityProvider.token" in calls["cmd"]
+
+    def test_user_identityprovider_token_equals_not_duplicated(self, monkeypatch):
+        # gh #69: the exact repro — a pinned token via the equals form must NOT be
+        # doubled, or jupyter_server aborts "token only accepts one value, got 2".
+        calls = self._run_main(
+            ["--no-browser", "--IdentityProvider.token=MyPinnedToken"], monkeypatch
+        )
+        assert self._token_value_count(calls["cmd"]) == 1  # exactly one, the user's
+        assert "--IdentityProvider.token=MyPinnedToken" in calls["cmd"]
+        # ...and the launcher did NOT add its own space-form token on top.
+        assert "--IdentityProvider.token" not in calls["cmd"]
+
+    def test_user_identityprovider_token_space_form_not_duplicated(self, monkeypatch):
+        calls = self._run_main(
+            ["--no-browser", "--IdentityProvider.token", "SpaceTok"], monkeypatch
+        )
+        assert self._token_value_count(calls["cmd"]) == 1
+        # the user's space-form pair rides through untouched, and only once
+        assert calls["cmd"].count("--IdentityProvider.token") == 1
+        assert "SpaceTok" in calls["cmd"]
+
+    def test_serverapp_token_alias_not_duplicated(self, monkeypatch):
+        # The --ServerApp.token alias gets the same treatment.
+        calls = self._run_main(
+            ["--no-browser", "--ServerApp.token=AliasTok"], monkeypatch
+        )
+        assert self._token_value_count(calls["cmd"]) == 1
+        assert "--IdentityProvider.token" not in calls["cmd"]  # ours not injected
+        assert "--ServerApp.token=AliasTok" in calls["cmd"]
+
+    def test_user_token_is_wired_to_the_agent_env(self, monkeypatch):
+        # The agent's notebook tools authenticate with LANGSTAGE_JUPYTER_TOKEN; when
+        # the user pins the server's token, that env must carry the SAME value or the
+        # tools would 403 against the very server they launched.
+        calls = self._run_main(
+            ["--no-browser", "--IdentityProvider.token=MyPinnedToken"], monkeypatch
+        )
+        assert calls["env"]["LANGSTAGE_JUPYTER_TOKEN"] == "MyPinnedToken"
+        assert calls["env"]["DEEPAGENT_JUPYTER_TOKEN"] == "MyPinnedToken"
+
+
 class TestVerifyFlag:
     """--verify preflights the agent with one real turn via core.verify (ADR 0004)."""
 

--- a/tests/test_notebook_tools.py
+++ b/tests/test_notebook_tools.py
@@ -178,6 +178,72 @@ def test_modify_cell_clears_stale_outputs(offline, ws):
     assert c.source == "x = 2" and c.outputs == [] and c.execution_count is None
 
 
+# ── markdown authoring (gh #70) ──────────────────────────────────────
+
+
+def test_insert_markdown_cell_appends_a_markdown_cell(offline, ws):
+    nt.create_notebook("md.ipynb")
+    out = nt.insert_markdown_cell("# My Analysis\nIntro prose.", "md.ipynb")
+    assert "Inserted markdown cell at index 0" in out
+    cell = _cells("md.ipynb")[0]
+    assert cell.cell_type == "markdown"
+    assert cell.source == "# My Analysis\nIntro prose."
+
+
+def test_insert_markdown_cell_at_index_interleaves_with_code(offline, ws):
+    # The core Jupyter workflow: a markdown header above a code cell.
+    nt.create_notebook("mix.ipynb")
+    nt.insert_code_cell("import pandas as pd", "mix.ipynb")
+    nt.insert_markdown_cell("# Title", "mix.ipynb", 0)  # insert BEFORE the code
+    cells = _cells("mix.ipynb")
+    assert [c.cell_type for c in cells] == ["markdown", "code"]
+    assert cells[0].source == "# Title"
+
+
+def test_insert_markdown_cell_missing_notebook_is_an_error_string(offline, ws):
+    out = nt.insert_markdown_cell("# hi", "nope.ipynb")
+    assert isinstance(out, str) and out.startswith("Error:") and "not found" in out.lower()
+
+
+def test_insert_markdown_cell_out_of_range_index(offline, ws):
+    nt.create_notebook("r.ipynb")
+    out = nt.insert_markdown_cell("# hi", "r.ipynb", 5)
+    assert "out of range" in out
+
+
+def test_modify_cell_can_edit_a_markdown_cell(offline, ws):
+    # gh #70: modify_cell used to hard-refuse any non-code cell, so a title/header
+    # a user already wrote could not be edited. It must now replace markdown source.
+    nt.create_notebook("edit.ipynb")
+    nt.insert_markdown_cell("# Old Title", "edit.ipynb")
+    out = nt.modify_cell("edit.ipynb", 0, "# Revised Title")
+    assert "Modified cell at index 0" in out
+    cell = _cells("edit.ipynb")[0]
+    assert cell.cell_type == "markdown"  # type preserved
+    assert cell.source == "# Revised Title"
+
+
+def test_modify_cell_empty_string_still_refuses_for_markdown(offline, ws):
+    # The empty-string sentinel must carry over to markdown — an empty edit must
+    # not silently blank/delete the cell (gh #70).
+    nt.create_notebook("s.ipynb")
+    nt.insert_markdown_cell("# Keep", "s.ipynb")
+    out = nt.modify_cell("s.ipynb", 0, "")
+    assert out.startswith("Error:") and "delete_cell" in out
+    assert _cells("s.ipynb")[0].source == "# Keep"
+
+
+def test_markdown_tools_are_registered_and_state_counts_them(offline, ws):
+    # The tool must actually be handed to the agent, and get_notebook_state (which
+    # already previews markdown) must reflect an inserted markdown cell.
+    assert nt.insert_markdown_cell in nt.NOTEBOOK_TOOLS
+    nt.create_notebook("c.ipynb")
+    nt.insert_markdown_cell("# Heading", "c.ipynb")
+    state = nt.get_notebook_state("c.ipynb")
+    assert "Markdown cells: 1" in state
+    assert "(markdown) # Heading" in state
+
+
 def test_read_cell_returns_full_source(offline, ws):
     nt.create_notebook("r.ipynb")
     nt.insert_code_cell("line1\nline2", "r.ipynb")


### PR DESCRIPTION
## Summary

Two independent, in-style fixes from the nightly dogfood backlog. One commit per issue; version bumped to **0.6.16** with CHANGELOG entries for both.

Closes #69
Closes #70

---

### #69 — Launcher crashed when the user pinned an auth token

`main()` in `langstage_jupyter/launcher.py` **unconditionally** injected its own `--IdentityProvider.token <auto>` before appending pass-through args. Passing your own `--IdentityProvider.token=...` (or the `--ServerApp.token=` alias) — a standard `jupyter lab` argument the README advertises as supported and uses in its Manual-Config section — made jupyter_server see the token twice and abort:

```
ValueError: token only accepts one value, got 2: ['<auto>', '<user-token>']
```

The server never started, and the error named a value the user never typed (the launcher's own injected token). This was the untreated **token twin of the already-fixed `--port` duplicate (#40)**.

**Fix:** a new `_find_user_token()` (mirrors the `--port` scan: both space and equals forms, both accepted names) detects a user-supplied token; the launcher then respects it — does **not** inject its own — and wires that value into `LANGSTAGE_JUPYTER_TOKEN` so the agent's notebook tools authenticate against the launched server. An explicitly empty `--IdentityProvider.token=` (auth disabled) is honored too.

Before/after (exact issue repro, `--IdentityProvider.token=MyPinnedToken`): the launched command now carries the token value exactly once, and `LANGSTAGE_JUPYTER_TOKEN=MyPinnedToken`.

### #70 — The agent could only author/edit CODE cells

The notebook toolset only ever touched code cells: there was no `insert_markdown_cell`, and `modify_cell` hard-refused any non-code cell (`Error: Cell N is not a code cell`). So the agent could write and run code but could not add a title, a section header, or narrative prose — nor edit markdown the user already wrote. The gap was silent and confusing because `get_notebook_state` **shows** markdown cells to the agent, so the model would try to edit one and hit a dead end.

**Fix:**
- New **`insert_markdown_cell(text, notebook_path, cell_index=-1)`** — the markdown twin of `insert_code_cell` (same server-first `_save_notebook` I/O, same error contract), registered in `NOTEBOOK_TOOLS`, re-exported from `agent.py`, and documented in the agent's system prompt.
- **`modify_cell` now edits markdown too** — replaces the source of code *and* markdown cells, clearing outputs/execution count only for code (markdown has neither). Its empty-string sentinel still refuses to blank a cell, for markdown as well.

---

## Testing

Full suite green: **179 passed, 1 skipped** (the pre-existing opt-in `serve_check` integration test), up from 167.

- `tests/test_launcher.py::TestTokenHandling` — 5 new cases: the exact #69 repro (equals form), the space form, the `--ServerApp.token` alias, the no-token baseline (still injects exactly one), and the agent-env wiring.
- `tests/test_notebook_tools.py` — 8 new cases: insert (append / interleave / missing notebook / out-of-range), the #70 modify-markdown repro, the empty-string sentinel for markdown, and registration + `get_notebook_state` count wiring.

Both exact issue repros were also run directly against the installed package and confirmed fixed.

## Notes
- `langstage_jupyter/_version.py` is a Hatchling build artifact and intentionally **not** committed; only `package.json` carries the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFhpZ6DJkyCM6sQB99uNY
