### PR TITLE
fix: make the README "Creating a Custom Agent" example valid Python (Closes #72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 
-## 0.6.16 - 2026-07-14
+## 0.6.17 - 2026-07-15
+
+### Fixed
+- **The README's "Creating a Custom Agent" example is now valid, runnable Python (gh #72).**
+  The custom-agent block — the file the docs tell you to save as `my_agent.py` — carried a
+  placeholder line that is a `SyntaxError`:
+
+      tools=[...your_custom_tools...]
+
+  `[...your_custom_tools...]` does not parse, so a first-time user who copied the block verbatim,
+  pointed `LANGSTAGE_AGENT_SPEC=./my_agent.py:agent` at it, and launched got an agent that **never
+  loaded** (`[fail] could not load agent: invalid syntax. Perhaps you forgot a comma?`, 🔴
+  `agent_not_loaded`) — a parse error that never pointed at the placeholder. Since the README
+  frames the block as a complete file, the placeholder read as real code, and this sat on the
+  headline "bring your own agent" onramp. The line is now the valid, self-documenting
+  `tools=[],  # add your custom tools here, e.g. [my_tool, another_tool]`, so the documented file
+  loads as-is and comes up as a langstage-jupyter agent. A new `tests/test_readme_examples.py`
+  lifts the example straight out of README.md, compiles it, and loads it through the same
+  `file.py:attr` host loader the launcher's `-a` uses — so the block can't silently regress.
 
 ### Fixed
 - **Pinning the auth token no longer crashes the launcher (gh #69).** The launcher

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ agent = create_deep_agent(
     model="anthropic:claude-sonnet-4-20250514",
     backend=FilesystemBackend(root_dir=workspace, virtual_mode=True),
     checkpointer=MemorySaver(),
-    tools=[...your_custom_tools...]
+    tools=[],  # add your custom tools here, e.g. [my_tool, another_tool]
 )
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -1,0 +1,78 @@
+"""Validate the runnable code examples in README.md so they cannot regress.
+
+#72 — the README's "Using Custom Agents → Creating a Custom Agent" block (the
+file it tells you to save as `my_agent.py`) shipped a placeholder line that is
+not valid Python:
+
+    tools=[...your_custom_tools...]
+
+`[...your_custom_tools...]` is a `SyntaxError`, so a newcomer who copied the
+block verbatim, pointed `LANGSTAGE_AGENT_SPEC=./my_agent.py:agent` at it, and
+launched got an agent that never loaded (`could not load agent: invalid
+syntax`) — on the primary "bring your own agent" onramp. The README frames the
+block as a complete file, so the placeholder read as real code.
+
+These tests lift the example straight out of README.md and (1) compile it, so a
+`SyntaxError` fails the suite, and (2) load it through the *same* host loader the
+launcher's `-a file.py:attr` uses, proving the documented file actually comes up
+as a langstage-jupyter agent. Building the agent needs no provider API key (the
+model is constructed lazily), so this runs in CI unmodified.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_README = (_REPO / "README.md").read_text(encoding="utf-8")
+
+
+def _readme_code_block(heading: str, *, must_contain: str) -> str:
+    """Return the first ```python fenced block after a README `### heading`.
+
+    `must_contain` is a sanity anchor: if the README is restructured and this
+    no longer captures the intended snippet, the test fails loudly here rather
+    than silently validating the wrong block.
+    """
+    anchor = _README.index(f"### {heading}")
+    m = re.search(r"```python\n(.*?)\n```", _README[anchor:], re.DOTALL)
+    assert m, f"no ```python block found after '### {heading}'"
+    code = m.group(1)
+    assert must_contain in code, (
+        f"README '{heading}' block no longer contains {must_contain!r} — "
+        "the extraction anchor is stale, update this test"
+    )
+    return code
+
+
+_CUSTOM_AGENT_EXAMPLE = _readme_code_block(
+    "Creating a Custom Agent", must_contain="create_deep_agent"
+)
+
+
+def test_custom_agent_example_is_valid_python():
+    """#72: the custom-agent block must compile — no `SyntaxError` verbatim."""
+    # compile() raises SyntaxError (failing the test) on the bad placeholder line.
+    compile(_CUSTOM_AGENT_EXAMPLE, "README.md#creating-a-custom-agent", "exec")
+
+
+def test_custom_agent_example_loads_as_an_agent(tmp_path, monkeypatch):
+    """#72: the documented file loads via the launcher's own `file.py:attr` loader.
+
+    Writes the README block verbatim to `my_agent.py` and resolves it exactly as
+    `langstage-jupyter -a ./my_agent.py:agent` does — through
+    `langstage_core.load_agent_spec` — asserting it yields the named graph.
+    """
+    from langstage_core import load_agent_spec
+
+    # No provider key needed to build; drop any so the test proves it too.
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    agent_file = tmp_path / "my_agent.py"
+    agent_file.write_text(_CUSTOM_AGENT_EXAMPLE, encoding="utf-8")
+
+    graph = load_agent_spec(f"{agent_file}:agent")
+
+    # The name the README sets, and a graph that could actually run a turn.
+    assert getattr(graph, "name", None) == "my-custom-agent"
+    assert hasattr(graph, "invoke"), "loaded object is not a runnable graph"


### PR DESCRIPTION
## What & why

The README's **"Using Custom Agents → Creating a Custom Agent"** block — the file the docs tell you to save as `my_agent.py` — carried a placeholder line that is **not valid Python**:

```python
    tools=[...your_custom_tools...]
```

`[...your_custom_tools...]` is a `SyntaxError`, so a first-time user who copied the block verbatim, pointed `LANGSTAGE_AGENT_SPEC=./my_agent.py:agent` at it, and launched got an agent that **never loaded** — the launcher reported `[fail] could not load agent: invalid syntax. Perhaps you forgot a comma?` and `/health` went 🔴 `agent_not_loaded`, with a parse error that never pointed at the placeholder. The README frames the block as a complete file, so the placeholder read as real code — and this sits on the headline "bring your own agent" onramp.

## Fix

Replace the placeholder with valid, self-documenting Python (the fix suggested in the issue):

```python
    tools=[],  # add your custom tools here, e.g. [my_tool, another_tool]
```

The example is the only copy in the repo (no `docs/` duplicate).

## How it was verified

The corrected block was written to a file and loaded three ways with the shipped launcher/loader:

- `python -c "import my_agent; print(type(my_agent.agent).__name__, my_agent.agent.name)"` → `CompiledStateGraph my-custom-agent`
- `load_agent_spec("my_agent.py:agent")` (the launcher's own `file.py:attr` loader) → `CompiledStateGraph my-custom-agent`, **with `ANTHROPIC_API_KEY` unset** (the model is built lazily, so no key is needed to load)
- `langstage-jupyter -a my_agent.py:agent --verify` now gets **past the load step** and runs a real turn (it only stops at the model call). Against the original broken line the same command failed at load with `[fail] could not load agent: invalid syntax` — confirming the placeholder was the sole blocker.

## Regression guard

New `tests/test_readme_examples.py` lifts the example straight out of `README.md` and:
1. `compile()`s it — a `SyntaxError` fails the suite;
2. loads it through the same `langstage_core.load_agent_spec` (`file.py:attr`) path the launcher's `-a` uses, asserting the graph is named `my-custom-agent`.

No provider key required, so it runs in CI unmodified.

## Tests

Full suite green locally (Python 3.11, Windows): **181 passed, 1 skipped** (the skip is pre-existing). Version bumped `0.6.16 → 0.6.17`; CHANGELOG updated. `_version.py` (a Hatchling build artifact) is intentionally not touched.

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFhpZ6DJkyCM6sQB99uNY
