### PR TITLE
fix: handle malformed numeric environment values

### DIFF
--- a/langstage_jupyter/config.py
+++ b/langstage_jupyter/config.py
@@ -8,9 +8,10 @@ env+defaults view (no TOML) kept for back-compat with existing call sites
 (``agent.py``, ``agent_wrapper.py``).
 """
 import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, ClassVar, Optional
+from typing import Any, Callable, ClassVar, Optional, cast
 
 from langstage_core.host import HostConfig, load_toml_config  # noqa: F401  (re-exported for callers)
 
@@ -72,6 +73,46 @@ class LabConfig(HostConfig):
         "virtual_mode": "jupyter.virtual_mode",
         "execute_timeout": "jupyter.execute_timeout",
     }
+
+    @classmethod
+    def resolve(
+        cls,
+        *,
+        overrides: Optional[dict[str, Any]] = None,
+        toml_start: Optional[Path] = None,
+        env: Optional[dict[str, str]] = None,
+        use_toml: bool = True,
+    ) -> "LabConfig":
+        """Resolve config, ignoring malformed numeric environment values."""
+        clean_env = dict(os.environ if env is None else env)
+        numeric_env = (
+            ("LANGSTAGE_MODEL_TEMPERATURE", "DEEPAGENT_MODEL_TEMPERATURE"),
+            ("LANGSTAGE_EXECUTE_TIMEOUT", "DEEPAGENT_EXECUTE_TIMEOUT"),
+        )
+        for canonical, legacy in numeric_env:
+            used = canonical if clean_env.get(canonical) else legacy
+            value = clean_env.get(used)
+            if value in (None, ""):
+                continue
+            try:
+                float(value)
+            except (TypeError, ValueError):
+                print(
+                    f"note: ignoring malformed {used}={value!r}; "
+                    "using TOML or default instead.",
+                    file=sys.stderr,
+                )
+                clean_env.pop(canonical, None)
+                clean_env.pop(legacy, None)
+        return cast(
+            "LabConfig",
+            super().resolve(
+                overrides=overrides,
+                toml_start=toml_start,
+                env=clean_env,
+                use_toml=use_toml,
+            ),
+        )
 
 
 # Module-level constants derived from LabConfig, for call sites that read

--- a/tests/test_labconfig.py
+++ b/tests/test_labconfig.py
@@ -48,6 +48,24 @@ def test_env_layer(isolated, tmp_path):
     assert cfg.agent_spec == "x.py:g"
 
 
+@pytest.mark.parametrize(
+    ("env_var", "field", "default"),
+    [
+        ("LANGSTAGE_MODEL_TEMPERATURE", "model_temperature", 0.0),
+        ("DEEPAGENT_MODEL_TEMPERATURE", "model_temperature", 0.0),
+        ("LANGSTAGE_EXECUTE_TIMEOUT", "execute_timeout", 300.0),
+        ("DEEPAGENT_EXECUTE_TIMEOUT", "execute_timeout", 300.0),
+    ],
+)
+def test_malformed_numeric_env_uses_default(
+    isolated, tmp_path, capsys, env_var, field, default
+):
+    cfg = LabConfig.resolve(env={env_var: "invalid"}, toml_start=tmp_path)
+
+    assert getattr(cfg, field) == default
+    assert env_var in capsys.readouterr().err
+
+
 def test_toml_layer(isolated, tmp_path):
     _toml(tmp_path,
           '[model]\nname = "anthropic:claude-3"\ntemperature = 0.3\n'


### PR DESCRIPTION
Malformed model temperature and execution timeout environment values no longer crash imports and every CLI entrypoint with a raw `ValueError`. Invalid canonical or legacy values are ignored with a note that names the offending variable, allowing TOML or defaults to take over.

Regression coverage proves all four variable spellings fail before the fix and pass after it; 29 config tests pass. The full suite's 17 network-sandbox port failures are identical on the baseline.

Fixes #75
