### PR TITLE
fix: a malformed numeric env var no longer crashes every entrypoint (Closes #75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.6.18 - 2026-07-16
+
+### Fixed
+- **A malformed numeric env var no longer crashes every entrypoint with a raw `ValueError` (gh #75).**
+  A non-numeric `LANGSTAGE_MODEL_TEMPERATURE` or `LANGSTAGE_EXECUTE_TIMEOUT` (or their legacy
+  `DEEPAGENT_*` spellings) — e.g. `0,5` (the European decimal comma), `5m`, or `abc` — was coerced
+  with a bare `float()` inside `LabConfig.resolve()`. Because config resolves at **import time**
+  (`_cfg = LabConfig.resolve()` in `config.py`), the uncaught `ValueError` took down *every*
+  entrypoint — `--version`/`--help`/`--show-config`/`--demo`, the `deepagent-lab` alias, the
+  launcher, the Jupyter server extension, and even a bare `import langstage_jupyter` — with a
+  traceback rooted in `langstage_core/host/config.py` that never named the offending variable.
+  This was the untreated sibling of #42 (a malformed `langstage.toml`, already hardened), which
+  degrades gracefully to `note: ignoring malformed config …; using environment + defaults instead`.
+  The two numeric env casters are now **lenient**: a malformed value degrades to the field default
+  and prints a one-line stderr note that names the variable, the bad value, and the default it fell
+  back to (`note: ignoring malformed LANGSTAGE_MODEL_TEMPERATURE='0,5' (ValueError: …); using
+  default 0.0 instead.`) — so a typo in one advertised config knob can no longer brick library
+  import or the CLI. A well-formed value still parses; unset (and empty) still uses the default.
+
 ## 0.6.17 - 2026-07-15
 
 ### Fixed

--- a/langstage_jupyter/config.py
+++ b/langstage_jupyter/config.py
@@ -8,11 +8,55 @@ env+defaults view (no TOML) kept for back-compat with existing call sites
 (``agent.py``, ``agent_wrapper.py``).
 """
 import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Optional
 
 from langstage_core.host import HostConfig, load_toml_config  # noqa: F401  (re-exported for callers)
+
+
+# Malformed numeric env values already noted — so a bad value is flagged ONCE even
+# though several surfaces each resolve the config in one process: the import-time
+# ``_cfg`` below, plus ``--show-config`` / ``--verify`` / the launcher, which each
+# call ``resolve()`` again. Mirrors langstage_core's ``_warned_legacy_env`` /
+# ``_warned_malformed_toml`` dedupe so one typo doesn't spam identical notes.
+_warned_malformed_env: set = set()
+
+
+def _lenient_number(cast: Callable[[str], Any], canonical_var: str, default: Any) -> Callable[[str], Any]:
+    """Wrap a numeric env caster (``float``/``int``) so a malformed value degrades
+    to the default with a one-line stderr note instead of crashing every entrypoint.
+
+    Mirrors #42's malformed-TOML handling. Because ``LabConfig.resolve()`` runs at
+    import time (``_cfg`` below), a bad numeric env value — ``LANGSTAGE_MODEL_TEMPERATURE``
+    or ``LANGSTAGE_EXECUTE_TIMEOUT`` (or their legacy ``DEEPAGENT_*`` spellings) set to
+    e.g. ``"abc"`` or ``"0,5"`` — used to let a raw ``ValueError`` from ``caster(ev)``
+    escape and take down ``--version``/``--help``/``--show-config``, the launcher, the
+    server extension, and even a bare ``import langstage_jupyter`` (gh #75). Now, exactly
+    like #42's ``note: ignoring malformed config …; using environment + defaults instead``
+    for a broken ``langstage.toml``, we skip the bad value, name the offending variable
+    and the raw value it choked on (an improvement on #42's file-only message), and fall
+    back to the field default so every entrypoint stays alive. ``canonical_var`` is the
+    ``LANGSTAGE_*`` name ``--show-config`` advertises; the legacy ``DEEPAGENT_*`` spelling
+    resolves through the same caster.
+    """
+
+    def _cast(value: str) -> Any:
+        try:
+            return cast(value)
+        except (ValueError, TypeError) as exc:
+            key = (canonical_var, value)
+            if key not in _warned_malformed_env:
+                _warned_malformed_env.add(key)
+                print(
+                    f"note: ignoring malformed {canonical_var}={value!r} "
+                    f"({type(exc).__name__}: {exc}); using default {default!r} instead.",
+                    file=sys.stderr,
+                )
+            return default
+
+    return _cast
 
 
 def get_config(key: str, default: Any = None, type_cast: Optional[Callable] = None) -> Any:
@@ -58,9 +102,19 @@ class LabConfig(HostConfig):
         "jupyter_token": ("DEEPAGENT_JUPYTER_TOKEN", str),
         "jupyter_server_url": ("DEEPAGENT_JUPYTER_SERVER_URL", str),
         "model_name": ("DEEPAGENT_MODEL_NAME", str),
-        "model_temperature": ("DEEPAGENT_MODEL_TEMPERATURE", float),
+        # Lenient numeric casters: a malformed value degrades to the field default
+        # with a stderr note (mirroring #42's malformed-TOML path) instead of letting
+        # a raw ValueError crash every entrypoint at import time (gh #75). Defaults are
+        # referenced from the fields above so the fallback can't drift from them.
+        "model_temperature": (
+            "DEEPAGENT_MODEL_TEMPERATURE",
+            _lenient_number(float, "LANGSTAGE_MODEL_TEMPERATURE", model_temperature),
+        ),
         "virtual_mode": ("DEEPAGENT_VIRTUAL_MODE", _to_bool),
-        "execute_timeout": ("DEEPAGENT_EXECUTE_TIMEOUT", float),
+        "execute_timeout": (
+            "DEEPAGENT_EXECUTE_TIMEOUT",
+            _lenient_number(float, "LANGSTAGE_EXECUTE_TIMEOUT", execute_timeout),
+        ),
     }
     _TOML: ClassVar[dict] = {
         "agent_module": "agent.module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,21 @@ def _restore_workspace_root():
                 os.environ[k] = v
 
 
+@pytest.fixture(autouse=True)
+def _reset_malformed_env_dedupe():
+    """Clear the once-per-value malformed-numeric-env notice dedupe between tests.
+
+    ``config._warned_malformed_env`` (gh #75) suppresses a repeat note for the same
+    bad value across the multiple ``resolve()`` calls in one process. It is
+    process-global, so without a reset a test that already tripped ``(var, "abc")``
+    would silence the note a later test asserts on — test order shouldn't decide
+    whether the note fires."""
+    import langstage_jupyter.config as _cfg
+    _cfg._warned_malformed_env.clear()
+    yield
+    _cfg._warned_malformed_env.clear()
+
+
 @pytest.fixture
 def clean_env(monkeypatch):
     """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -110,6 +110,27 @@ class TestConfigConstants:
         assert config.DEBUG is False
         assert config.VIRTUAL_MODE is True
 
+    @pytest.mark.parametrize("var, const, default", [
+        ("LANGSTAGE_MODEL_TEMPERATURE", "MODEL_TEMPERATURE", 0.0),
+        ("LANGSTAGE_EXECUTE_TIMEOUT", "EXECUTE_TIMEOUT", 300.0),
+    ])
+    def test_malformed_numeric_env_does_not_break_import(
+        self, clean_env, mock_env, capsys, var, const, default
+    ):
+        """gh #75: a malformed numeric env var must not crash module import.
+
+        config.py resolves the config at import time (``_cfg = LabConfig.resolve()``),
+        so before the fix a non-numeric ``LANGSTAGE_MODEL_TEMPERATURE`` / ``_EXECUTE_TIMEOUT``
+        (here ``0,5`` — the European decimal comma from the issue) let a raw ValueError
+        escape and take down even a bare ``import langstage_jupyter``. It must now reload
+        cleanly, falling back to the default (parity with #42's malformed-TOML path)."""
+        mock_env(var, "0,5")
+        import importlib
+        from langstage_jupyter import config
+        importlib.reload(config)  # must NOT raise
+        assert getattr(config, const) == default
+        assert "malformed" in capsys.readouterr().err
+
     def test_environment_overrides(self, clean_env, mock_env):
         """Should override defaults with environment variables."""
         mock_env("DEEPAGENT_AGENT_MODULE", "custom.agent")

--- a/tests/test_labconfig.py
+++ b/tests/test_labconfig.py
@@ -76,3 +76,75 @@ def test_describe_lists_var_names(isolated, tmp_path):
     assert "DEEPAGENT_JUPYTER_TOKEN" in text
     assert "jupyter.token" in text
     assert "DEEPAGENT_AGENT_SPEC" in text
+
+
+# ── gh #75: a malformed numeric env var must degrade gracefully, not crash ──
+#
+# Sibling of the already-fixed #42 (malformed langstage.toml). Before the fix,
+# a non-numeric LANGSTAGE_MODEL_TEMPERATURE / LANGSTAGE_EXECUTE_TIMEOUT let a raw
+# ValueError from float() escape resolve() and take down every entrypoint —
+# including a bare `import langstage_jupyter`, since config resolves at import
+# time. It must now fall back to the field default with a one-line stderr note
+# that names the offending variable + value (parity with #42's TOML path).
+
+# (canonical env var, field, expected default) for the two lenient-cast knobs.
+_NUMERIC_KNOBS = [
+    ("LANGSTAGE_MODEL_TEMPERATURE", "model_temperature", 0.0),
+    ("LANGSTAGE_EXECUTE_TIMEOUT", "execute_timeout", 300.0),
+]
+
+
+@pytest.mark.parametrize("var, field, default", _NUMERIC_KNOBS)
+@pytest.mark.parametrize("bad", ["abc", "0,5", "5m", "0.0.0", " "])
+def test_malformed_numeric_env_falls_back_to_default(
+    isolated, tmp_path, capsys, var, field, default, bad
+):
+    """A malformed numeric env value resolves to the default (no exception)."""
+    cfg = LabConfig.resolve(env={var: bad}, toml_start=tmp_path)  # must NOT raise
+    assert getattr(cfg, field) == default
+
+
+@pytest.mark.parametrize("var, field, default", _NUMERIC_KNOBS)
+def test_malformed_numeric_env_notes_the_variable_and_value(
+    isolated, tmp_path, capsys, var, field, default
+):
+    """The stderr note names the offending variable and the bad value it choked on."""
+    LabConfig.resolve(env={var: "abc"}, toml_start=tmp_path)
+    err = capsys.readouterr().err
+    assert "malformed" in err
+    assert var in err          # names the canonical LANGSTAGE_* variable
+    assert "abc" in err        # ...and the value that failed to parse
+    assert str(default) in err  # ...and the default it fell back to
+
+
+@pytest.mark.parametrize("var, field, default", _NUMERIC_KNOBS)
+def test_malformed_numeric_env_via_legacy_spelling(
+    isolated, tmp_path, capsys, var, field, default
+):
+    """The legacy DEEPAGENT_* spelling degrades identically (same caster)."""
+    legacy = var.replace("LANGSTAGE_", "DEEPAGENT_")
+    cfg = LabConfig.resolve(env={legacy: "abc"}, toml_start=tmp_path)  # must NOT raise
+    assert getattr(cfg, field) == default
+    assert "malformed" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("var, field, value", [
+    ("LANGSTAGE_MODEL_TEMPERATURE", "model_temperature", "0.7"),
+    ("LANGSTAGE_EXECUTE_TIMEOUT", "execute_timeout", "60"),
+])
+def test_valid_numeric_env_still_parses(isolated, tmp_path, capsys, var, field, value):
+    """A well-formed value still parses to a float, with no note printed."""
+    cfg = LabConfig.resolve(env={var: value}, toml_start=tmp_path)
+    assert getattr(cfg, field) == float(value)
+    assert "malformed" not in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("var, field, default", _NUMERIC_KNOBS)
+def test_unset_numeric_env_uses_default_without_note(
+    isolated, tmp_path, capsys, var, field, default
+):
+    """Unset (and empty, treated as unset) keeps the default and prints no note."""
+    for env in ({}, {var: ""}):
+        cfg = LabConfig.resolve(env=env, toml_start=tmp_path)
+        assert getattr(cfg, field) == default
+    assert "malformed" not in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Closes #75 — the untreated sibling of #42 (a malformed `langstage.toml`, already hardened).

A non-numeric `LANGSTAGE_MODEL_TEMPERATURE` or `LANGSTAGE_EXECUTE_TIMEOUT` (or their legacy `DEEPAGENT_*` spellings) — e.g. `0,5` (the European decimal comma), `5m`, or `abc` — was coerced with a bare `float()` in `LabConfig`'s `_ENV` map. Because `config.py` resolves the config **at import time** (`_cfg = LabConfig.resolve()`), the uncaught `ValueError` from `caster(ev)` (`langstage_core/host/config.py:398`) took down **every** entrypoint — `--version`/`--help`/`--show-config`/`--demo`, the `deepagent-lab` alias, the launcher, the Jupyter server extension, and even a bare `import langstage_jupyter` — with a traceback that never named the offending variable.

### Repro (before)
```console
$ LANGSTAGE_MODEL_TEMPERATURE=abc python -c "import langstage_jupyter"
...
  File ".../langstage_core/host/config.py", line 398, in resolve
    val = caster(ev)
ValueError: could not convert string to float: 'abc'
```

### After
```console
$ LANGSTAGE_MODEL_TEMPERATURE=abc python -c "import langstage_jupyter; print('import OK')"
note: ignoring malformed LANGSTAGE_MODEL_TEMPERATURE='abc' (ValueError: could not convert string to float: 'abc'); using default 0.0 instead.
import OK
```

## How #42 handled TOML, and how this mirrors it for env

Issue #42 hardened `langstage_core`'s `_read_toml`: catch the parse exception, print `note: ignoring malformed config …; using environment + defaults instead`, fall back — keeping `import` and the CLI alive. `resolve()` and the numeric `caster(ev)` live upstream in `langstage-core`, so this change hardens the coercion at the one place `langstage-jupyter` owns it: the two `float` casters in `LabConfig._ENV`.

A small `_lenient_number(...)` wrapper makes each numeric env caster degrade a malformed value to the **field default** with a one-line stderr note that names the **variable, the bad value, and the default** it fell back to (an improvement on the file-only message from #42). The note is deduped once-per-value across a process's multiple `resolve()` calls (import-time `_cfg` + `--show-config`/`--verify`), matching langstage_core's own `_warned_legacy_env` / `_warned_malformed_toml` idiom. Defaults are referenced from the fields themselves so the fallback can't drift.

## Behavior
- Malformed value (`abc`, `0,5`, `5m`, `0.0.0`, whitespace) → default + one note; every entrypoint stays alive.
- Legacy `DEEPAGENT_*` spelling → degrades identically (same caster).
- Well-formed value → still parses (e.g. `0.7`, `60`).
- Unset / empty → still uses the default, no note.

## Tests (fail-before / pass-after)
- `tests/test_labconfig.py`: parametrized over both vars — malformed values fall back to default without raising; the note names variable + value + default; legacy spelling degrades identically; valid values still parse; unset/empty use the default with no note.
- `tests/test_config.py`: a malformed value no longer breaks module import (config resolves at import time), falling back to the default.
- `tests/conftest.py`: autouse fixture resets the once-per-value note dedupe between tests.

Confirmed the new tests **fail** on the pre-fix code with the exact raw `ValueError`, and **pass** after. Full suite green locally: **201 passed, 1 skipped** (Python 3.11, `langstage-core` 1.0.19).

## Version
`package.json` 0.6.17 → 0.6.18 + CHANGELOG entry. `langstage_jupyter/_version.py` left untracked (gitignored, auto-generated at build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFhpZ6DJkyCM6sQB99uNY