### PR TITLE
fix: a generated token starting with `-` no longer blocks the launch (gh #79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.6.19 - 2026-07-18
+
+### Fixed
+- **An auto-generated token that happens to start with `-` no longer stops JupyterLab from
+  starting at all (gh #79).** The headline zero-config launcher generates its auth token with
+  `secrets.token_urlsafe(32)` and injected it space-separated —
+  `['--IdentityProvider.token', token]`. `token_urlsafe` draws from the **base64url** alphabet,
+  which includes `-`, so roughly **1.57% of launches** (about 1 in 64) produced a token beginning
+  with `-`; `jupyter lab`'s argparse then read that value as another option flag and aborted before
+  the server ever booted: `argument --IdentityProvider.token: expected one argument`, exit 2. No
+  `/lab`, no chat sidebar, no health endpoint — the documented "recommended, zero-configuration"
+  entrypoint failed outright. The failure was maximally confusing to diagnose: it depended only on
+  the random draw, so it looked flaky rather than broken, the error never named the token *value*,
+  and re-running the identical command usually worked. The launcher now emits the **equals form**,
+  `--IdentityProvider.token=<token>` — a single argv entry that can never be re-split, so a leading
+  `-` is inert. This is the shape the launcher already *recognized* on input from users
+  (`_find_user_token` handles both forms) and already *emitted* itself for `--serve-check`
+  (`--ServerApp.token={token}`); only the auto path still used the fragile spelling. A
+  leading-dash `JUPYTER_TOKEN` taken from the environment rides the same emission path and is now
+  safe too. This is the third trigger in the launcher's arg-injection family, after #40 (duplicate
+  `--port`) and #69 (duplicate user-pinned token), and it does not disturb either: the
+  duplicate-token scan reads the *user's* args, never the argv the launcher builds, so a pinned
+  token is still respected and still not doubled. New regression tests pin a leading-dash token
+  deterministically and assert the emitted argv is accepted by traitlets'
+  `KVArgParseConfigLoader` — the very parser that produced the crash.
+
 ## 0.6.18 - 2026-07-16
 
 ### Fixed

--- a/langstage_jupyter/launcher.py
+++ b/langstage_jupyter/launcher.py
@@ -671,8 +671,17 @@ def main():
     # Inject our token only when the user didn't pin one themselves — otherwise
     # jupyter_server sees the token twice and aborts (gh #69, the token twin of #40).
     # The user's own --IdentityProvider.token/--ServerApp.token rides through in `args`.
+    #
+    # Emit the EQUALS form, never `['--IdentityProvider.token', token]`. `token_urlsafe`
+    # draws from the base64url alphabet, so ~1.6% of generated tokens start with `-`;
+    # in the space form jupyter lab's argparse reads that value as another option flag
+    # and aborts before booting — `argument --IdentityProvider.token: expected one
+    # argument`, no server, no sidebar, and it "works on re-run" (gh #79). `--opt=value`
+    # is never re-split, so a leading `-` is safe. This also covers a leading-dash
+    # JUPYTER_TOKEN from the environment, and matches --serve-check's
+    # f"--ServerApp.token={token}" above.
     if user_token is None:
-        jupyter_args.extend(['--IdentityProvider.token', token])
+        jupyter_args.append(f'--IdentityProvider.token={token}')
 
     # Add any user-provided arguments
     jupyter_args.extend(args)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -367,10 +367,12 @@ class TestTokenHandling:
         return n
 
     def test_no_token_arg_auto_injects_one(self, monkeypatch):
-        # Baseline: with no user token, the launcher injects exactly one.
+        # Baseline: with no user token, the launcher injects exactly one — in the
+        # equals form, so a leading-`-` token can't be misparsed as a flag (gh #79).
         calls = self._run_main(["--no-browser"], monkeypatch)
         assert self._token_value_count(calls["cmd"]) == 1
-        assert "--IdentityProvider.token" in calls["cmd"]
+        assert any(a.startswith("--IdentityProvider.token=") for a in calls["cmd"])
+        assert "--IdentityProvider.token" not in calls["cmd"]  # never the space form
 
     def test_user_identityprovider_token_equals_not_duplicated(self, monkeypatch):
         # gh #69: the exact repro — a pinned token via the equals form must NOT be
@@ -410,6 +412,120 @@ class TestTokenHandling:
         )
         assert calls["env"]["LANGSTAGE_JUPYTER_TOKEN"] == "MyPinnedToken"
         assert calls["env"]["DEEPAGENT_JUPYTER_TOKEN"] == "MyPinnedToken"
+
+
+#: A token shaped exactly like one `secrets.token_urlsafe(32)` really produces
+#: ~1.6% of the time: base64url alphabet, leading `-`. (gh #79)
+LEADING_DASH_TOKEN = "-infrKxamplZtokenThatStartsWithDash1234567"
+
+
+def _traitlets_accepts(argv):
+    """Does the parser `jupyter lab` actually uses accept ``argv``?
+
+    JupyterLab parses its command line with traitlets' ``KVArgParseConfigLoader``
+    (an argparse loader), which is what emits
+    ``argument --IdentityProvider.token: expected one argument`` and exits 2 when a
+    value looks like a flag. Driving the real loader — rather than asserting on a
+    hand-rolled imitation — is what makes this regression test meaningful.
+    """
+    from traitlets.config.loader import KVArgParseConfigLoader
+
+    loader = KVArgParseConfigLoader(
+        argv=list(argv), aliases={}, flags={"no-browser": ({}, "no browser")}
+    )
+    try:
+        loader.load_config()
+    except SystemExit:  # argparse's parse error path
+        return False
+    return True
+
+
+class TestGeneratedTokenLeadingDash:
+    """The launcher's OWN generated token must never break its own launch (gh #79).
+
+    `secrets.token_urlsafe` uses the base64url alphabet, so ~1.57% of tokens start
+    with `-`. Emitted space-separated (`--IdentityProvider.token <tok>`), argparse
+    reads that value as another option flag and jupyter lab aborts before booting —
+    intermittent, ~1 in 64 launches, and it "works when you re-run it". Emitting the
+    equals form makes the value un-splittable.
+    """
+
+    def _run_main_with_token(self, argv, monkeypatch, token=LEADING_DASH_TOKEN):
+        calls = {}
+
+        def fake_run(cmd, env=None):
+            calls["cmd"] = cmd
+            calls["env"] = dict(env or {})
+            return MagicMock(returncode=0)
+
+        # Force the exact random draw that triggers the bug — deterministically.
+        monkeypatch.setattr(
+            "langstage_jupyter.launcher.secrets.token_urlsafe", lambda n: token
+        )
+        monkeypatch.setattr("langstage_jupyter.launcher.subprocess.run", fake_run)
+        monkeypatch.setattr("sys.argv", ["langstage-jupyter"] + argv)
+        monkeypatch.delenv("JUPYTER_TOKEN", raising=False)
+        with pytest.raises(SystemExit):  # main() propagates the child's exit code
+            main()
+        return calls
+
+    def test_generated_token_is_emitted_in_the_equals_form(self, monkeypatch):
+        calls = self._run_main_with_token(["--no-browser"], monkeypatch)
+        # One arg carrying flag AND value, so the leading `-` can never be re-read
+        # as a separate option.
+        assert f"--IdentityProvider.token={LEADING_DASH_TOKEN}" in calls["cmd"]
+        # ...and never the fragile space form that strands the value as its own argv
+        # entry.
+        assert "--IdentityProvider.token" not in calls["cmd"]
+        assert LEADING_DASH_TOKEN not in calls["cmd"]
+
+    def test_jupyter_lab_argparse_accepts_the_emitted_argv(self, monkeypatch):
+        """The load-bearing assertion: the real parser boots on what we emit."""
+        calls = self._run_main_with_token(["--no-browser"], monkeypatch)
+        # Drop the `python -m jupyterlab` prefix; the loader sees only the flags.
+        jupyter_flags = calls["cmd"][3:]
+        assert _traitlets_accepts(jupyter_flags)
+        # Sanity-check the harness itself: the OLD space form really does abort, so a
+        # green result above can't be the assertion silently passing on anything.
+        assert not _traitlets_accepts(
+            ["--IdentityProvider.token", LEADING_DASH_TOKEN, "--no-browser"]
+        )
+
+    def test_generated_token_reaches_the_agent_env_intact(self, monkeypatch):
+        # The equals form must not mangle the value the notebook tools authenticate
+        # with — otherwise they'd 403 against the server they just launched.
+        calls = self._run_main_with_token(["--no-browser"], monkeypatch)
+        assert calls["env"]["LANGSTAGE_JUPYTER_TOKEN"] == LEADING_DASH_TOKEN
+        assert calls["env"]["DEEPAGENT_JUPYTER_TOKEN"] == LEADING_DASH_TOKEN
+
+    def test_leading_dash_jupyter_token_env_is_also_safe(self, monkeypatch):
+        # Same emission path covers a leading-dash JUPYTER_TOKEN from the environment.
+        calls = {}
+
+        def fake_run(cmd, env=None):
+            calls["cmd"] = cmd
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr("langstage_jupyter.launcher.subprocess.run", fake_run)
+        monkeypatch.setattr("sys.argv", ["langstage-jupyter", "--no-browser"])
+        monkeypatch.setenv("JUPYTER_TOKEN", LEADING_DASH_TOKEN)
+        with pytest.raises(SystemExit):
+            main()
+        assert f"--IdentityProvider.token={LEADING_DASH_TOKEN}" in calls["cmd"]
+        assert _traitlets_accepts(calls["cmd"][3:])
+
+    def test_user_pinned_token_still_not_duplicated(self, monkeypatch):
+        # Guard against regressing gh #69 while fixing #79: with a user-pinned token
+        # we still inject nothing, in either form.
+        calls = self._run_main_with_token(
+            ["--no-browser", "--IdentityProvider.token=MyPinnedToken"], monkeypatch
+        )
+        assert "--IdentityProvider.token=MyPinnedToken" in calls["cmd"]
+        assert f"--IdentityProvider.token={LEADING_DASH_TOKEN}" not in calls["cmd"]
+        assert "--IdentityProvider.token" not in calls["cmd"]
+        assert (
+            sum(a.startswith("--IdentityProvider.token") for a in calls["cmd"]) == 1
+        )
 
 
 class TestVerifyFlag:


### PR DESCRIPTION
Closes #79.

## The bug

The zero-config launcher generates its auth token with `secrets.token_urlsafe(32)` and injected it into the `jupyter lab` command line **space-separated** (`launcher.py:675`):

```python
jupyter_args.extend(['--IdentityProvider.token', token])
```

`token_urlsafe` draws from the base64url alphabet, which includes `-`. When the generated token happens to start with `-`, `jupyter lab`'s argparse reads that value as another option flag and aborts before the server ever boots:

```
jupyter-lab: error: argument --IdentityProvider.token: expected one argument
```

No `/lab`, no chat sidebar, no health endpoint — the documented "recommended, zero-configuration" entrypoint fails outright, at **~1.57% of launches** (roughly 1 in 64). Worst-case diagnosability: it depends only on the random draw, so it reads as flaky rather than broken; the error never names the token *value*; and re-running the identical command usually works.

## The fix

One line — emit the **equals form**:

```diff
-        jupyter_args.extend(['--IdentityProvider.token', token])
+        jupyter_args.append(f'--IdentityProvider.token={token}')
```

`--opt=value` is a single argv entry that is never re-split, so a leading `-` is inert.

This is not a new convention for this codebase, it's the one already in use on both sides:

- `_find_user_token` (`launcher.py:162-178`) already **recognizes** the equals form on input — verified, it handles `--IdentityProvider.token=TOK` and the `--ServerApp.token=` alias.
- `--serve-check` already **emits** it: `f"--ServerApp.token={token}"` (`launcher.py:268`).

Only the auto path still used the fragile spelling. A leading-dash `JUPYTER_TOKEN` taken from the environment rides the same emission path and is now safe too.

## Why the `=` form alone, and not also a dash-free token alphabet

Considered and deliberately rejected as a second mechanism. Constraining the generated alphabet would fix a strict *subset* of the same failure: it protects only the token the launcher generates, leaving a leading-dash `JUPYTER_TOKEN` from the environment — which flows through the exact same `jupyter_args` line — still broken. The `=` form covers every token this code path emits, whatever its source. Adding both would mean two overlapping guards for one bug, would fork our token generation away from `secrets.token_urlsafe`'s well-understood entropy contract for no gain, and would leave the weaker guard to rot. One mechanism, at the emission point, where the actual defect is.

## #69 does not regress — checked specifically

The concern was real: if the duplicate-token detection scanned the argv the launcher builds, changing its shape would silently un-fix #69. It does not.

- `_find_user_token(args)` is called at `launcher.py:623` on **`args`** — the user's pass-through arguments — *before* and independently of `jupyter_args` being assembled at line 664+.
- `jupyter_args` is never parsed back out. Confirmed by grep: its only consumers are `extend`/`append`, the `Launching:` log line, and `subprocess.run`.
- The injection is still gated on `if user_token is None`, unchanged.

So a user-pinned token is still detected, still respected, and still not doubled. `TestGeneratedTokenLeadingDash::test_user_pinned_token_still_not_duplicated` asserts this explicitly against a forced leading-dash generated token: the pinned value passes through exactly once and ours is not added in *either* form. The existing #69 tests pass untouched — their `_token_value_count` helper already counted both forms.

One pre-existing assertion needed updating: `test_no_token_arg_auto_injects_one` asserted the bare space form `"--IdentityProvider.token" in cmd`. It now asserts the equals form is present *and* the space form is absent — a stricter check than before.

## Test evidence

New `TestGeneratedTokenLeadingDash` monkeypatches `secrets.token_urlsafe` to return a token shaped exactly like a real one that triggers the bug, making the 1-in-64 race deterministic. The load-bearing assertion drives **traitlets' real `KVArgParseConfigLoader`** — the actual parser that emits `argument --IdentityProvider.token: expected one argument` — rather than a hand-rolled imitation, and includes a self-check that the old space form really is rejected by that same harness.

**Verified the tests fail without the fix.** Reverting `launcher.py` alone and re-running gives `4 failed, 15 passed`, with the real-parser test failing on the exact production error:

```
Launching: ...python.exe -m jupyterlab --port 8888 --IdentityProvider.token -infrKxamplZtokenThatStartsWithDash1234567 --no-browser
langstage-jupyter: error: argument --IdentityProvider.token: expected one argument
```

Restoring the fix turns all four green.

Full suite: **206 passed, 1 skipped** (was 201 passed, 1 skipped — +5 new tests).

Version bumped to 0.6.19 in `package.json` (hatch-nodejs-version) with a dated CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B
