### PR TITLE
fix: require core >= 1.0.21 so a wrong-typed langstage.toml value can't crash a cell (Closes #78)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,14 @@ jobs:
         pip install "jupyterlab>=4.0,<5"
         # AG-UI is the wrapper's only streaming path (core 1.0), so [agui] pulls
         # ag-ui-langgraph[fastapi] + uvicorn — tests/test_agui_stream.py runs, not skips.
-        pip install "langstage-core[agui]>=1.0"
+        # NOTE: this job installs a hand-listed dependency set rather than the
+        # package's own (a plain `pip install -e .` would fire the jupyter-builder
+        # hook and require Node here), so this floor must be kept in step with the
+        # `langstage-core` floor in pyproject.toml — otherwise CI silently tests
+        # against a core that predates a fix the package declares it needs, which
+        # is exactly what happened on gh #78 (>=1.0.21 carries the TOML type
+        # coercion). The `minimal-install` job is what exercises the declared deps.
+        pip install "langstage-core[agui]>=1.0.21"
         pip install nbformat requests tornado traitlets jupyter_client
 
     - name: Add package to Python path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 ## 0.6.19 - 2026-07-18
 
 ### Fixed
+- **A wrong-TYPE value in `langstage.toml` no longer sails through as a `str` and detonates
+  mid-notebook-run (gh #78).** Quoting a number — `execute_timeout = "300"`, one of the most
+  common TOML mistakes — was accepted verbatim for a field declared `float`, and `--show-config`
+  strips the quotes, so the bad value was *visually indistinguishable* from a correct one. The
+  failure then surfaced far from its cause: `notebook_tools.py`'s
+  `deadline = time.monotonic() + EXECUTE_TIMEOUT` died with a raw
+  `TypeError: unsupported operand type(s) for +: 'float' and 'str'` that never mentioned
+  `langstage.toml` or the offending key. This is the untreated sibling of the #75 env fix, whose
+  own suggested fix named the right layer: the repair belongs in `langstage-core`'s
+  `HostConfig._coerce`, which every stage resolves through, not in this one host. Requires
+  **langstage-core >= 1.0.21**, which is what actually delivers it — a coercible value is now
+  cast (`"300"` -> `300.0`), and an uncoercible one (`"warm"`, `true`) keeps the default, keeps
+  the `[default]` source attribution so `--show-config` can't advertise it as live, and prints a
+  one-line `note:` naming the file and key.
 - **An auto-generated token that happens to start with `-` no longer stops JupyterLab from
   starting at all (gh #79).** The headline zero-config launcher generates its auth token with
   `secrets.token_urlsafe(32)` and injected it space-separated —

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,12 @@ dependencies = [
     # is a HARD runtime requirement. A bare `pip install langstage-jupyter` must
     # be able to run a turn.
     # >=1.0.6 for the shared preflight primitive core.verify() used by --verify.
-    "langstage-core[agui]>=1.0.7",
+    # >=1.0.21 so a wrong-TYPE value in langstage.toml (a quoted number, a bool for
+    # a numeric field) is coerced or rejected with a note instead of being handed
+    # through as a str and crashing a cell execution with a raw TypeError. The fix
+    # lives in core's HostConfig._coerce, which this package resolves through, so
+    # the floor is what actually delivers it to an existing install (gh #78).
+    "langstage-core[agui]>=1.0.21",
     "python-dotenv>=0.19.0",
     "deepagents>=0.1.0",
     # Direct top-level imports in langstage_jupyter/agent.py. Previously only

--- a/tests/test_labconfig.py
+++ b/tests/test_labconfig.py
@@ -148,3 +148,51 @@ def test_unset_numeric_env_uses_default_without_note(
         cfg = LabConfig.resolve(env=env, toml_start=tmp_path)
         assert getattr(cfg, field) == default
     assert "malformed" not in capsys.readouterr().err
+
+
+# ── gh #78: a wrong-TYPE value in langstage.toml ─────────────────────────────
+# The untreated sibling of #75 (which hardened the *env* casters only). A quoted
+# number in TOML is syntactically valid but the wrong type, and it used to be
+# handed through verbatim: `execute_timeout = "300"` became the str '300' for a
+# field declared float, --show-config stripped the quotes so it looked correct,
+# and the defect surfaced far away as
+# `TypeError: unsupported operand type(s) for +: 'float' and 'str'` the first
+# time notebook_tools.py ran a cell. The repair lives in langstage-core's
+# HostConfig._coerce (>= 1.0.21), which LabConfig resolves through; these pin
+# that it actually reaches this stage.
+
+@pytest.mark.parametrize("body, field, expected", [
+    ('[jupyter]\nexecute_timeout = "300"\n', "execute_timeout", 300.0),
+    ('[model]\ntemperature = "0.5"\n', "model_temperature", 0.5),
+])
+def test_quoted_number_in_toml_is_coerced(isolated, tmp_path, body, field, expected):
+    _toml(tmp_path, body)
+    cfg = LabConfig.resolve(env={}, toml_start=tmp_path)
+    value = getattr(cfg, field)
+    assert value == expected
+    assert isinstance(value, float), f"{field} resolved as {type(value).__name__}"
+
+
+def test_coerced_timeout_survives_the_cell_execution_arithmetic(isolated, tmp_path):
+    """The exact expression from the issue: notebook_tools.py's deadline math."""
+    import time
+
+    _toml(tmp_path, '[jupyter]\nexecute_timeout = "300"\n')
+    cfg = LabConfig.resolve(env={}, toml_start=tmp_path)
+    assert time.monotonic() + cfg.execute_timeout > 0  # used to raise TypeError
+
+
+@pytest.mark.parametrize("body, field, default", [
+    ('[jupyter]\nexecute_timeout = "not-a-number"\n', "execute_timeout", 300.0),
+    ("[model]\ntemperature = true\n", "model_temperature", 0.0),
+])
+def test_uncoercible_toml_value_degrades_with_a_note(
+    isolated, tmp_path, capsys, body, field, default
+):
+    """Uncoercible keeps the default AND the 'default' source attribution, so
+    --show-config can never present an unusable value as a live TOML setting."""
+    _toml(tmp_path, body)
+    cfg = LabConfig.resolve(env={}, toml_start=tmp_path)
+    assert getattr(cfg, field) == default
+    assert cfg.sources[field] == "default"
+    assert "malformed" in capsys.readouterr().err


### PR DESCRIPTION
Closes #78.

## The problem

`execute_timeout = "300"` — a quoted number, one of the most common TOML mistakes — was accepted verbatim as a Python `str` for a field declared `float`. `--show-config` strips the quotes, so the bad value was **visually indistinguishable** from a correct one:

```
execute_timeout  = 300      [toml (langstage.toml)]     # actually the str '300'
```

The failure then surfaced far from its cause — `notebook_tools.py`'s `deadline = time.monotonic() + EXECUTE_TIMEOUT` dying with a raw `TypeError` that never mentioned `langstage.toml` or the offending key.

## Where the fix lives

Not here. This is the untreated sibling of the #75 env fix, and **#75's own suggested fix named the right layer**: the TOML path resolves through `langstage-core`'s `HostConfig._coerce`, which coerced `Path` fields only. Fixing it in core means every stage inherits it instead of one host getting a local patch.

That landed in **langstage-core 1.0.21** (dkedar7/langstage-core#101). What *this* package contributes is the dependency floor that actually delivers it — the old `>=1.0.7` would happily leave an existing install sitting on a core without the fix.

## Verification

Against a real install upgraded to core 1.0.21:

| `langstage.toml` | before | after |
|---|---|---|
| `execute_timeout = "300"` | `str '300'` → `TypeError` | `float 300.0`, arithmetic works |
| `temperature = "0.5"` | `str '0.5'` | `float 0.5` |
| `execute_timeout = "not-a-number"` | `str`, crash later | default + `note:` naming file and key |
| `temperature = true` | `bool True` | default + `note:` |

```
note: ignoring malformed jupyter.execute_timeout='not-a-number' in .../langstage.toml
      (ValueError: could not convert string to float: 'not-a-number'); using default 300.0 instead.
```

New tests in `tests/test_labconfig.py` pin that the behavior reaches this stage through `LabConfig` — including the issue's exact deadline arithmetic, and that an uncoercible value keeps the `default` **source attribution** so `--show-config` can't advertise it as live.

Full suite: **211 passed, 1 skipped**.

## Note

This rides along with the #79 launcher fix already on `main` in the unpublished 0.6.19, so both ship in one release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B