### PR TITLE
fix: fail the build if it would package a stale labextension (gh #82)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,10 +108,15 @@ jobs:
           /tmp/mi/bin/python -c "import langstage_jupyter; print('ok')"
           /tmp/mi/bin/python -c "import langstage_jupyter.config, langstage_jupyter.agent_wrapper, langstage_jupyter.handlers, langstage_jupyter.agent, langstage_jupyter.launcher; print('ok')"
 
-  # gh #38/#48 guard: the built wheel must bundle a labextension whose version
+  # gh #38/#48/#82 guard: the built wheel must bundle a labextension whose version
   # matches the wheel. The drift (skip-if-exists reusing a stale JS bundle) shipped
-  # a mislabelled labextension twice. This builds a release wheel and asserts parity;
-  # scripts/check_labext_version.py is the same check the release runs before publish.
+  # a mislabelled labextension THREE times. Note a clean CI checkout never has a
+  # stale artifact to reuse, so building a fresh wheel here can only ever *pass* —
+  # it does not reproduce the release-machine failure. So this job does two things:
+  # it builds a wheel with the real release command (`uv build`) and runs the
+  # pre-publish gate (scripts/check_labext_version.py), AND it positively proves
+  # the in-build guard (hatch_build.py) *rejects* a stale bundle, which is the
+  # condition that actually shipped.
   labext-version:
     runs-on: ubuntu-latest
     steps:
@@ -122,11 +127,27 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Build a release wheel (fresh labextension)
+      - uses: astral-sh/setup-uv@v5
+      - name: Build a release wheel with the real release command (fresh labextension)
         run: |
-          python -m pip install --upgrade pip build "jupyterlab>=4.0,<5"
+          python -m pip install --upgrade pip "jupyterlab>=4.0,<5"
           jlpm install --no-immutable
           jlpm build:prod
-          python -m build --wheel
+          uv build
       - name: Assert bundled labextension version == wheel version
         run: python scripts/check_labext_version.py
+      - name: The in-build guard must REJECT a stale labextension (gh #82)
+        run: |
+          # Simulate the exact drift: make the already-built bundle's version lag
+          # package.json (as a leftover previous-release build would), then assert
+          # `uv build` refuses to package it instead of shipping it silently.
+          python - <<'PY'
+          import json, pathlib
+          p = pathlib.Path("langstage_jupyter/labextension/package.json")
+          d = json.loads(p.read_text()); d["version"] = "0.0.0-stale"
+          p.write_text(json.dumps(d))
+          PY
+          if uv build --wheel; then
+            echo "FAIL: build succeeded while packaging a stale labextension"; exit 1
+          fi
+          echo "ok: the in-build guard rejected the stale labextension"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 0.6.20 - 2026-07-23
+
+### Fixed
+- **A release build can no longer ship a stale prebuilt labextension whose version
+  lags the package (gh #82).** A clean `pip install langstage-jupyter==0.6.19`
+  reported `0.6.19` for the Python package, the `--version` launcher, and the
+  server extension, but `jupyter labextension list` showed **`v0.6.11`** — the
+  bundled frontend asset (`share/jupyter/labextensions/langstage-jupyter/package.json`)
+  was a stale `0.6.11` build. To a user, the standard way to confirm a labextension
+  install then reads like a broken or half-applied upgrade, and JupyterLab's
+  extension manager keys "update available" off that frozen version. The root cause
+  is the `hatch-jupyter-builder` hook's `skip-if-exists`
+  (`langstage_jupyter/labextension/static/style.js`): a `uv build` run against a
+  working tree that still holds a *previous* release's `langstage_jupyter/labextension/`
+  **reuses that stale JS bundle instead of rebuilding it** — the build log literally
+  says `Skip-if-exists file(s) found` / `Skipping build`. The directory is
+  git-ignored, so the drift never appears in `git status`, and a clean CI checkout
+  has no stale artifact to reuse, so it never reproduces in CI. The mismatch is
+  therefore invisible everywhere except the maintainer's local release build — which
+  is exactly why this is the **third occurrence of the same drift** (previously
+  #38 and #48, both closed 2026-07-03). Each prior fix rebuilt the bundle for *that*
+  release and added `scripts/check_labext_version.py`, a pre-publish gate that asserts
+  the built wheel's bundled labextension version == the wheel version — but it had to
+  be run *by hand* before `uv publish` and simply wasn't before 0.6.19 shipped, so
+  eight Python-only releases (0.6.12 → 0.6.19) all carried the stale 0.6.11 frontend.
+  What makes it not recur this time: the same assertion now runs **inside the build
+  itself**. A new custom hatchling build hook (`hatch_build.py`, registered as
+  `[tool.hatch.build.hooks.custom]`) fires on every `uv build` / `pip wheel .` /
+  editable install and **hard-fails the build** when a bundled
+  `langstage_jupyter/labextension/` is present with a version that differs from
+  `package.json` — the stale bundle can no longer be *packaged*, so there is no
+  forgettable manual step and no wheel to accidentally publish. The check is narrow
+  and order-independent: when the labextension dir is absent (a clean tree) the
+  jupyter-builder hook rebuilds it fresh — matching `package.json` by construction —
+  and the guard stays silent. The `labext-version` CI job now also runs `uv build`
+  and asserts parity so the guard's own failure path is exercised, and a regression
+  test pins that a deliberately-stale bundle raises.
+
 ## 0.6.19 - 2026-07-18
 
 ### Fixed

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,97 @@
+"""Build-time guard: the bundled labextension version MUST equal package.json.
+
+Why this exists (gh #82 — the *third* occurrence of #38/#48): the
+``hatch-jupyter-builder`` hook is configured with ``skip-if-exists``
+(``langstage_jupyter/labextension/static/style.js``). So a real release build --
+``uv build`` run against a working tree that still holds a *previous* release's
+``langstage_jupyter/labextension/`` -- reuses that stale JS bundle instead of
+rebuilding it. ``jupyter labextension list`` then reports the old version while
+``pip`` / ``--version`` / the server extension report the new one (an
+advertised-vs-honored mismatch). The directory is git-ignored, so the drift never
+shows up in ``git status`` and a clean CI checkout has no stale artifact to reuse
+-- the failure is *local to the maintainer's release machine*, which is exactly
+why it slipped through three times.
+
+``scripts/check_labext_version.py`` was added to catch this against a built
+wheel, but it has to be run *by hand* before ``uv publish`` and simply wasn't
+before 0.6.19 shipped. A safeguard a human can forget is not a safeguard. This
+hook moves the *same* assertion INTO the build itself: it runs on every
+``uv build`` / ``pip wheel .`` / editable install and raises, so a wheel that
+would bundle a stale labextension can never be produced -- the build fails loudly
+instead of silently packaging the wrong frontend. No manual step to remember.
+
+The check is deliberately narrow and order-independent: it only fires when a
+built ``langstage_jupyter/labextension/`` is present *and* its version differs
+from ``package.json``. When the directory is absent (a clean tree) the
+jupyter-builder hook rebuilds it fresh -- which matches ``package.json`` by
+construction -- so there is nothing to assert and this hook stays silent.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+try:
+    from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+except ModuleNotFoundError:  # pragma: no cover
+    # hatchling is a *build* backend, not a runtime/test dependency. Keep the
+    # parity logic below importable (the regression test imports it) even where
+    # the build backend isn't installed; the hook class is only needed when
+    # hatchling actually drives a build, and hatchling is present by definition
+    # then.
+    BuildHookInterface = None
+
+_LABEXT_MANIFEST = ("langstage_jupyter", "labextension", "package.json")
+
+
+class LabextVersionError(Exception):
+    """Raised when the bundled labextension version drifts from package.json."""
+
+
+def _read_version(manifest: Path) -> str:
+    return json.loads(manifest.read_text(encoding="utf-8"))["version"]
+
+
+def verify_labext_version(root: str | Path) -> str | None:
+    """Assert a bundled labextension's version matches ``package.json``.
+
+    ``root`` is the project root (the directory holding ``package.json``).
+
+    Returns the agreed version string when a bundled labextension is present and
+    matches; returns ``None`` when no bundled labextension is present yet (a
+    clean tree -- the jupyter-builder hook will build it fresh, which matches by
+    construction). Raises :class:`LabextVersionError` when a bundled
+    labextension is present but its version differs from ``package.json`` -- the
+    gh #82 stale-reuse condition that ``skip-if-exists`` would otherwise package.
+    """
+    root = Path(root)
+    pkg_version = _read_version(root / "package.json")
+    labext_manifest = root.joinpath(*_LABEXT_MANIFEST)
+    if not labext_manifest.exists():
+        # Nothing built yet; the jupyter-builder hook produces a fresh bundle
+        # (== package.json). Only a *reused* bundle can be stale.
+        return None
+    labext_version = _read_version(labext_manifest)
+    if labext_version != pkg_version:
+        raise LabextVersionError(
+            f"bundled labextension version {labext_version!r} != package.json "
+            f"version {pkg_version!r}. A stale langstage_jupyter/labextension/ is "
+            f"about to be packaged -- the hatch-jupyter-builder skip-if-exists "
+            f"guard reused a previous release's JS bundle instead of rebuilding "
+            f"it (gh #82; third recurrence of #38/#48). Rebuild the labextension "
+            f"cleanly, then re-run the build:\n"
+            f"    jlpm clean:labextension && jlpm build:prod"
+        )
+    return pkg_version
+
+
+if BuildHookInterface is not None:
+
+    class LabextVersionGuard(BuildHookInterface):
+        """Fail the build if the bundled labextension version != package.json."""
+
+        PLUGIN_NAME = "labext-version-guard"
+
+        def initialize(self, version, build_data):  # noqa: ARG002 - hatch signature
+            verify_labext_version(self.root)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,19 @@ npm = ["jlpm"]
 source_dir = "src"
 build_dir = "lib"
 
+# gh #82 (third recurrence of #38/#48): the jupyter-builder `skip-if-exists`
+# above reuses a leftover `langstage_jupyter/labextension/` from a *previous*
+# release build, so `uv build` can package a stale JS bundle whose version
+# lags `package.json` (labextension reports the old version; pip/--version the
+# new one). The dir is git-ignored and CI checks out clean, so the drift is
+# invisible to `git status` and never reproduces in CI -- it shipped three
+# times. This custom hook (`hatch_build.py`) runs on every build and hard-fails
+# it when a bundled labextension is present but its version != `package.json`,
+# turning `scripts/check_labext_version.py`'s manual, forgettable pre-publish
+# check into a guarantee enforced inside the build itself.
+[tool.hatch.build.hooks.custom]
+path = "hatch_build.py"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/tests/test_labext_version_guard.py
+++ b/tests/test_labext_version_guard.py
@@ -1,0 +1,97 @@
+"""gh #82 guard: the bundled labextension version must track package.json.
+
+The published 0.6.19 wheel bundled a stale 0.6.11 labextension because the
+`hatch-jupyter-builder` `skip-if-exists` guard reused a leftover
+`langstage_jupyter/labextension/` from an earlier build (the third time this
+drift shipped — see #38/#48). The durable fix moved the parity assertion *into*
+the build: a custom hatchling build hook (`hatch_build.py`) hard-fails any build
+that would package a labextension whose version differs from `package.json`.
+
+These tests exercise that guard's decision logic directly — including a
+deliberately-stale tree, which is the exact condition that shipped three times —
+so a future regression in the hook is caught here, in the fast Python suite, not
+only at release time. `hatch_build.py` lives at the repo root (a build-time
+module, not part of the installed package), so it is loaded by path.
+"""
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+# tomllib is stdlib on 3.11+ (this package requires >=3.11).
+import tomllib
+
+_REPO = Path(__file__).resolve().parent.parent
+
+
+def _load_hatch_build():
+    """Import the repo-root build hook module by path."""
+    path = _REPO / "hatch_build.py"
+    spec = importlib.util.spec_from_file_location("hatch_build", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_hb = _load_hatch_build()
+
+
+def _make_tree(tmp_path: Path, pkg_version: str, labext_version: str | None) -> Path:
+    """Build a fake project root with a package.json and (optionally) a bundled
+    labextension package.json at the given versions."""
+    (tmp_path / "package.json").write_text(
+        json.dumps({"name": "langstage-jupyter", "version": pkg_version}),
+        encoding="utf-8",
+    )
+    if labext_version is not None:
+        labext = tmp_path / "langstage_jupyter" / "labextension"
+        labext.mkdir(parents=True)
+        (labext / "package.json").write_text(
+            json.dumps({"name": "langstage-jupyter", "version": labext_version}),
+            encoding="utf-8",
+        )
+    return tmp_path
+
+
+def test_guard_raises_on_stale_bundled_labextension(tmp_path):
+    """The exact gh #82 failure: a leftover 0.6.11 bundle in a 0.6.20 tree."""
+    root = _make_tree(tmp_path, pkg_version="0.6.20", labext_version="0.6.11")
+    with pytest.raises(_hb.LabextVersionError) as exc:
+        _hb.verify_labext_version(root)
+    msg = str(exc.value)
+    assert "0.6.11" in msg and "0.6.20" in msg
+    # The error must be actionable — it names the clean-rebuild command.
+    assert "jlpm" in msg and "build:prod" in msg
+
+
+def test_guard_passes_on_matching_versions(tmp_path):
+    root = _make_tree(tmp_path, pkg_version="0.6.20", labext_version="0.6.20")
+    assert _hb.verify_labext_version(root) == "0.6.20"
+
+
+def test_guard_is_silent_when_no_labextension_built(tmp_path):
+    """A clean tree (no bundled labextension) must NOT fail: the jupyter-builder
+    hook rebuilds it fresh, which matches package.json by construction."""
+    root = _make_tree(tmp_path, pkg_version="0.6.20", labext_version=None)
+    assert _hb.verify_labext_version(root) is None
+
+
+def test_repo_tree_satisfies_the_guard():
+    """The real working tree must never be in the stale state the guard forbids.
+
+    When the labextension has not been built (e.g. the CI test job has no Node),
+    the guard returns None and this passes. When it *has* been built, its version
+    must equal package.json — a live parity check on the actual repo."""
+    _hb.verify_labext_version(_REPO)  # must not raise
+
+
+def test_package_json_is_the_single_version_source():
+    """hatch derives the wheel version from package.json (hatch-nodejs-version),
+    so the guard comparing against package.json is comparing against the wheel
+    version. Pin that wiring so a switch away from it doesn't silently defeat the
+    guard."""
+    pyproject = tomllib.loads((_REPO / "pyproject.toml").read_text(encoding="utf-8"))
+    assert pyproject["tool"]["hatch"]["version"]["source"] == "nodejs"
+    # And the custom guard hook is actually registered.
+    assert "custom" in pyproject["tool"]["hatch"]["build"]["hooks"]


### PR DESCRIPTION
## Summary

Closes #82. The published **0.6.19** wheel bundled a **0.6.11** labextension: `pip`, `langstage-jupyter --version`, and the server extension all reported `0.6.19`, but `jupyter labextension list` showed `v0.6.11` because the wheel shipped a stale prebuilt frontend. This is the **third occurrence** of the same drift (#38, #48).

## Root cause

The `hatch-jupyter-builder` hook's `skip-if-exists` (`langstage_jupyter/labextension/static/style.js`) **reuses a leftover `langstage_jupyter/labextension/` from a previous release build**. A `uv build` run against such a tree ships the old JS bundle (whose `package.json` still reports the old version) while the Python metadata bumps. The build log literally reads `Skip-if-exists file(s) found` / `Skipping build`.

The directory is **git-ignored** and a clean CI checkout has no stale artifact to reuse, so the drift is invisible to `git status` and never reproduces in CI — it only bites the maintainer's local release build. `scripts/check_labext_version.py` was added to catch it against a built wheel, but it has to be run **by hand** before `uv publish` and simply wasn't before 0.6.19. A safeguard a human can forget is not a safeguard.

## Fix — make it structurally impossible

Move the assertion **into the build itself**. A new custom hatchling build hook (`hatch_build.py`, registered as `[tool.hatch.build.hooks.custom]`) runs on every `uv build` / `pip wheel .` / editable install and **hard-fails the build** when a bundled labextension is present whose version differs from `package.json`. A stale bundle can no longer be *packaged* — there is no forgettable manual step and no wheel to accidentally publish. The check is narrow and order-independent: a clean tree (no bundled labextension) rebuilds fresh via jupyter-builder — matching `package.json` by construction — and the guard stays silent.

Also in this PR:
- Bump `package.json` `0.6.19` → `0.6.20` (rebuilt the labextension bundle to match) + CHANGELOG entry.
- The `labext-version` CI job now builds with the real release command (`uv build`), runs the pre-publish gate, **and** positively proves the in-build guard *rejects* a deliberately-stale bundle. (Previously it built a fresh wheel from a clean checkout, which can only ever pass — it never exercised the failure that actually shipped.)
- New regression test (`tests/test_labext_version_guard.py`) pins that a stale bundle raises and a matching/absent one does not.

## Acceptance (from a clean tree)

```
$ uv build
Building source distribution...
INFO:hatch_jupyter_builder.utils:Skip-if-exists file(s) found
...
Successfully built dist\langstage_jupyter-0.6.20.tar.gz
Successfully built dist\langstage_jupyter-0.6.20-py3-none-any.whl

$ python scripts/check_labext_version.py dist/langstage_jupyter-0.6.20-py3-none-any.whl
ok langstage_jupyter-0.6.20-py3-none-any.whl: wheel == labextension == 0.6.20
(exit 0)

# bundled asset inside the wheel:
langstage_jupyter-0.6.20.data/data/share/jupyter/labextensions/langstage-jupyter/package.json
bundled version: 0.6.20
```

Reproduction before the fix (stale 0.6.11 bundle + version bumped to 0.6.20): the wheel bundled 0.6.11 and the gate printed `MISMATCH ... wheel version '0.6.20' != bundled labextension version '0.6.11'`. With the guard in place, that same stale tree makes `uv build` **fail** with `LabextVersionError` instead of producing a wheel.

## Tests

Full suite: **216 passed, 1 skipped** (211 baseline + 5 new guard tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B