### PR TITLE
fix(config): a malformed env var no longer discards a valid langstage.toml value (Closes #83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.6.21 - 2026-07-23
+
+### Fixed
+- **A malformed numeric env var no longer silently discards a valid `langstage.toml` value
+  (gh #83).** The #75 fix stopped a bad `LANGSTAGE_MODEL_TEMPERATURE` / `LANGSTAGE_EXECUTE_TIMEOUT`
+  from crashing every entrypoint, but it did so with a local `_lenient_number` wrapper that
+  returned the field **default** directly on a bad value — short-circuiting config precedence. So a
+  malformed env var of a key that a valid `langstage.toml` also set didn't just get ignored: it
+  *clobbered* the user's explicit config with the built-in default, and `--show-config` mislabeled
+  the source as `[env:...]` — actively confirming the wrong source to anyone debugging "why is my
+  temperature 0.0?". The numeric casters are now plain `float`, delegating to
+  `HostConfig.resolve()`, which since **langstage-core 1.0.23** (#104) catches the caster error,
+  emits the note, and keeps the value from the layer *beneath* env — the `langstage.toml` value if
+  one is set, else the default — with the source correctly attributed. This removes the local
+  leniency shim entirely (one place, in core, handles it for every stage). Requires
+  **langstage-core >= 1.0.23**.
+
 ## 0.6.20 - 2026-07-23
 
 ### Fixed

--- a/langstage_jupyter/config.py
+++ b/langstage_jupyter/config.py
@@ -16,47 +16,13 @@ from typing import Any, Callable, ClassVar, Optional
 from langstage_core.host import HostConfig, load_toml_config  # noqa: F401  (re-exported for callers)
 
 
-# Malformed numeric env values already noted — so a bad value is flagged ONCE even
-# though several surfaces each resolve the config in one process: the import-time
-# ``_cfg`` below, plus ``--show-config`` / ``--verify`` / the launcher, which each
-# call ``resolve()`` again. Mirrors langstage_core's ``_warned_legacy_env`` /
-# ``_warned_malformed_toml`` dedupe so one typo doesn't spam identical notes.
-_warned_malformed_env: set = set()
-
-
-def _lenient_number(cast: Callable[[str], Any], canonical_var: str, default: Any) -> Callable[[str], Any]:
-    """Wrap a numeric env caster (``float``/``int``) so a malformed value degrades
-    to the default with a one-line stderr note instead of crashing every entrypoint.
-
-    Mirrors #42's malformed-TOML handling. Because ``LabConfig.resolve()`` runs at
-    import time (``_cfg`` below), a bad numeric env value — ``LANGSTAGE_MODEL_TEMPERATURE``
-    or ``LANGSTAGE_EXECUTE_TIMEOUT`` (or their legacy ``DEEPAGENT_*`` spellings) set to
-    e.g. ``"abc"`` or ``"0,5"`` — used to let a raw ``ValueError`` from ``caster(ev)``
-    escape and take down ``--version``/``--help``/``--show-config``, the launcher, the
-    server extension, and even a bare ``import langstage_jupyter`` (gh #75). Now, exactly
-    like #42's ``note: ignoring malformed config …; using environment + defaults instead``
-    for a broken ``langstage.toml``, we skip the bad value, name the offending variable
-    and the raw value it choked on (an improvement on #42's file-only message), and fall
-    back to the field default so every entrypoint stays alive. ``canonical_var`` is the
-    ``LANGSTAGE_*`` name ``--show-config`` advertises; the legacy ``DEEPAGENT_*`` spelling
-    resolves through the same caster.
-    """
-
-    def _cast(value: str) -> Any:
-        try:
-            return cast(value)
-        except (ValueError, TypeError) as exc:
-            key = (canonical_var, value)
-            if key not in _warned_malformed_env:
-                _warned_malformed_env.add(key)
-                print(
-                    f"note: ignoring malformed {canonical_var}={value!r} "
-                    f"({type(exc).__name__}: {exc}); using default {default!r} instead.",
-                    file=sys.stderr,
-                )
-            return default
-
-    return _cast
+# The malformed-numeric-env handling that used to live here (a `_lenient_number`
+# wrapper that returned the field default directly) is gone: it short-circuited config
+# precedence (a bad env var clobbered a valid langstage.toml value and mislabeled the
+# source), and langstage-core 1.0.23 (#104) now handles a malformed numeric env var in
+# HostConfig.resolve() itself — catching the caster error, emitting the note, and
+# keeping the value from the layer beneath env. The casters below are plain float/int
+# and delegate to that. (gh #83)
 
 
 def get_config(key: str, default: Any = None, type_cast: Optional[Callable] = None) -> Any:
@@ -102,19 +68,17 @@ class LabConfig(HostConfig):
         "jupyter_token": ("DEEPAGENT_JUPYTER_TOKEN", str),
         "jupyter_server_url": ("DEEPAGENT_JUPYTER_SERVER_URL", str),
         "model_name": ("DEEPAGENT_MODEL_NAME", str),
-        # Lenient numeric casters: a malformed value degrades to the field default
-        # with a stderr note (mirroring #42's malformed-TOML path) instead of letting
-        # a raw ValueError crash every entrypoint at import time (gh #75). Defaults are
-        # referenced from the fields above so the fallback can't drift from them.
-        "model_temperature": (
-            "DEEPAGENT_MODEL_TEMPERATURE",
-            _lenient_number(float, "LANGSTAGE_MODEL_TEMPERATURE", model_temperature),
-        ),
+        # Plain numeric casters: a malformed value is handled by the base
+        # HostConfig.resolve(), which (since langstage-core 1.0.23, #104) catches the
+        # caster error, emits a one-line note, and keeps the value from the layer
+        # BENEATH env — a langstage.toml value if one is set, else the field default.
+        # The old _lenient_number wrapper here returned the field default DIRECTLY,
+        # which short-circuited that precedence: a malformed env var discarded a valid
+        # langstage.toml value and mislabeled the source as env (gh #83). Delegating to
+        # core fixes both, and de-duplicates the leniency into one place.
+        "model_temperature": ("DEEPAGENT_MODEL_TEMPERATURE", float),
         "virtual_mode": ("DEEPAGENT_VIRTUAL_MODE", _to_bool),
-        "execute_timeout": (
-            "DEEPAGENT_EXECUTE_TIMEOUT",
-            _lenient_number(float, "LANGSTAGE_EXECUTE_TIMEOUT", execute_timeout),
-        ),
+        "execute_timeout": ("DEEPAGENT_EXECUTE_TIMEOUT", float),
     }
     _TOML: ClassVar[dict] = {
         "agent_module": "agent.module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     # through as a str and crashing a cell execution with a raw TypeError. The fix
     # lives in core's HostConfig._coerce, which this package resolves through, so
     # the floor is what actually delivers it to an existing install (gh #78).
-    "langstage-core[agui]>=1.0.21",
+    "langstage-core[agui]>=1.0.23",
     "python-dotenv>=0.19.0",
     "deepagents>=0.1.0",
     # Direct top-level imports in langstage_jupyter/agent.py. Previously only

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,15 +39,16 @@ def _restore_workspace_root():
 def _reset_malformed_env_dedupe():
     """Clear the once-per-value malformed-numeric-env notice dedupe between tests.
 
-    ``config._warned_malformed_env`` (gh #75) suppresses a repeat note for the same
-    bad value across the multiple ``resolve()`` calls in one process. It is
+    The dedupe now lives in langstage-core (``_warned_malformed_env_value``, #104):
+    since gh #83 this package delegates malformed-numeric-env handling to
+    ``HostConfig.resolve()`` rather than its own ``_lenient_number`` wrapper. It is
     process-global, so without a reset a test that already tripped ``(var, "abc")``
     would silence the note a later test asserts on — test order shouldn't decide
     whether the note fires."""
-    import langstage_jupyter.config as _cfg
-    _cfg._warned_malformed_env.clear()
+    import langstage_core.host.config as _core_cfg
+    getattr(_core_cfg, "_warned_malformed_env_value", set()).clear()
     yield
-    _cfg._warned_malformed_env.clear()
+    getattr(_core_cfg, "_warned_malformed_env_value", set()).clear()
 
 
 @pytest.fixture

--- a/tests/test_labconfig.py
+++ b/tests/test_labconfig.py
@@ -196,3 +196,23 @@ def test_uncoercible_toml_value_degrades_with_a_note(
     assert getattr(cfg, field) == default
     assert cfg.sources[field] == "default"
     assert "malformed" in capsys.readouterr().err
+
+
+# ── gh #83: a malformed env var must not clobber a valid langstage.toml value ────
+@pytest.mark.parametrize("var, field, toml_body, toml_val", [
+    ("LANGSTAGE_MODEL_TEMPERATURE", "model_temperature", "[model]\ntemperature = 0.7\n", 0.7),
+    ("LANGSTAGE_EXECUTE_TIMEOUT", "execute_timeout", "[jupyter]\nexecute_timeout = 120\n", 120.0),
+])
+def test_malformed_env_keeps_the_toml_value(isolated, tmp_path, capsys, var, field, toml_body, toml_val):
+    """The precedence half of #83: env sits above TOML, so a REJECTED env var must
+    fall through to the TOML value that a valid config set — not skip straight to the
+    built-in default (which the old _lenient_number wrapper did), and --show-config
+    must credit toml, not the rejected env var."""
+    _toml(tmp_path, toml_body)
+    cfg = LabConfig.resolve(env={var: "notanumber"}, toml_start=tmp_path)
+
+    assert getattr(cfg, field) == toml_val, "malformed env clobbered the langstage.toml value"
+    assert cfg.sources[field].startswith("toml"), "source mislabeled as env for a rejected value"
+    # the note names what it kept — the TOML value, not "default"
+    err = capsys.readouterr().err
+    assert "ignoring malformed" in err and str(toml_val) in err


### PR DESCRIPTION
Closes #83.

The #75 fix stopped a malformed `LANGSTAGE_MODEL_TEMPERATURE` / `LANGSTAGE_EXECUTE_TIMEOUT` from crashing every entrypoint — but it did so with a local `_lenient_number` wrapper that returned the field **default** directly on a bad value, short-circuiting config precedence.

So a malformed env var of a key that a valid `langstage.toml` *also* set didn't just get ignored — it **clobbered** the explicit config with the built-in default, and `--show-config` mislabeled the source as `[env:...]`:

```console
$ cat langstage.toml
[model]
temperature = 0.7

BEFORE  (malformed env wins, wrongly)
$ LANGSTAGE_MODEL_TEMPERATURE=notanumber langstage-jupyter --show-config | grep temperature
  model_temperature = 0.0    [env:LANGSTAGE_MODEL_TEMPERATURE]   <- should be 0.7, source toml

AFTER
  model_temperature = 0.7    [toml (langstage.toml)]
  note: ignoring malformed LANGSTAGE_MODEL_TEMPERATURE='notanumber' (...); using 0.7 (toml (langstage.toml)) instead.
```

## The fix — delete the shim, delegate to core

The numeric casters are now plain `float`. `LabConfig` inherits `HostConfig.resolve()`, which since **langstage-core 1.0.23** (#104) catches the caster error itself, emits the note, and keeps the value from the layer *beneath* env — the `langstage.toml` value if set, else the default — with the source correctly attributed. So the local `_lenient_number` (the source of the precedence bug) is removed entirely: one place, in core, now handles this for every stage. Core floor bumped to `>= 1.0.23`.

## Verification

- Dogfooded the issue's exact repro: TOML value kept (0.7 / 120.0), source credited `toml`.
- New `test_malformed_env_keeps_the_toml_value` pins both halves (value + source); it fails against the old `_lenient_number` and passes now. The existing `test_malformed_numeric_env_*` (no-TOML → default) still pass, unchanged.
- Full suite **218 passed, 1 skipped** (the labextension version-guard from #82 stays green — labext rebuilt to 0.6.21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B