### PR TITLE
fix: --show-config no longer reports a malformed langstage.toml as absent (gh #86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.6.22 - 2026-07-23
+
+### Fixed
+- **`--show-config` no longer reports a present-but-malformed `langstage.toml` as absent
+  (gh #86).** When a `langstage.toml` exists but has a syntax error, the *same* command
+  printed two contradictory statements: the stderr note (from langstage-core) correctly
+  said `note: ignoring malformed config /…/langstage.toml (TOMLDecodeError: …)` — the file
+  *was* found — while the stdout footer said `TOML: no langstage.toml (or legacy
+  deepagents.toml) found`, claiming it doesn't exist. A present-but-unparseable file
+  rendered *identically* to no file at all, so a user debugging "why isn't my
+  `langstage.toml` applied?" was pointed at file location / naming instead of the real
+  cause (a syntax typo already flagged on stderr). The root cause is that
+  `HostConfig.describe()`'s footer keys purely off the *successfully-parsed* paths
+  (`_toml_paths`), which a malformed file leaves empty — collapsing it into the same
+  branch as genuine absence. `LabConfig` now overrides `resolve()` / `describe()` to also
+  consult langstage-core's malformed-file set (`_malformed_toml`, the #61/#42 tracking),
+  intersected with the files actually on *this* resolve's search path (the nearest
+  project `langstage.toml` / legacy `deepagents.toml` and the global config) so a stale
+  entry from an unrelated resolve can't leak in. When a file was found but rejected, the
+  footer now reads `TOML: found <path> but it is malformed (see the note above); using
+  environment + defaults` — agreeing with the stderr note instead of contradicting it. A
+  valid file still shows `TOML read from: <path>` and genuine absence still shows
+  `no langstage.toml … found`; both are untouched.
+
 ## 0.6.21 - 2026-07-23
 
 ### Fixed

--- a/langstage_jupyter/config.py
+++ b/langstage_jupyter/config.py
@@ -44,6 +44,39 @@ def _to_bool(value: str) -> bool:
     return str(value).strip().lower() in ("true", "1", "yes", "on")
 
 
+# The base ``HostConfig.describe()`` footer for the no-file case. We match on this
+# (via a stable prefix, below) to rewrite it when a file WAS found but couldn't be
+# parsed — see ``LabConfig.describe`` and gh #86.
+_ABSENT_TOML_FOOTER_PREFIX = "  TOML: no langstage.toml"
+
+
+def _malformed_config_paths(toml_start: Optional[Path] = None) -> list[Path]:
+    """Config files that exist on the resolved search path but failed to parse.
+
+    langstage-core records every path whose TOML parse raised in the module-level
+    ``_malformed_toml`` set (gh langstage-hermes #61/#42) and emits the one-line
+    ``note: ignoring malformed config <path> ...`` on stderr from there. That set is
+    process-global and accumulates across every ``resolve()`` in the process, so we
+    intersect it with the files actually on THIS resolve's search path — the nearest
+    project ``langstage.toml`` / legacy ``deepagents.toml`` and the global config — so a
+    stale entry from an unrelated resolve elsewhere in the process can't leak in. Returns
+    the found-but-malformed paths (usually zero or one), in global-then-project order.
+    """
+    from langstage_core.host import config as _core
+
+    malformed = getattr(_core, "_malformed_toml", set())
+    if not malformed:
+        return []
+    found: list[Path] = []
+    gpath = _core._global_toml_path()
+    if gpath.is_file() and str(gpath) in malformed:
+        found.append(gpath)
+    ppath = _core._find_project_toml(toml_start)
+    if ppath is not None and str(ppath) in malformed:
+        found.append(ppath)
+    return found
+
+
 @dataclass
 class LabConfig(HostConfig):
     """langstage-jupyter's view of the shared config.
@@ -90,6 +123,59 @@ class LabConfig(HostConfig):
         "virtual_mode": "jupyter.virtual_mode",
         "execute_timeout": "jupyter.execute_timeout",
     }
+
+    @classmethod
+    def resolve(cls, *, toml_start: Optional[Path] = None, **kwargs: Any) -> "LabConfig":
+        """Resolve config, additionally recording any found-but-malformed TOML.
+
+        Delegates to ``HostConfig.resolve`` and then, while ``toml_start`` is still in
+        hand, stashes the config files that exist on this resolve's search path but
+        failed to parse (``_malformed_config_paths``). ``describe()`` reads that back so
+        the ``--show-config`` footer can tell a present-but-unparseable ``langstage.toml``
+        apart from a genuinely absent one (gh #86) — the base footer keys purely off the
+        SUCCESSFULLY-parsed paths, so a malformed file collapses into "not found".
+        """
+        obj = super().resolve(toml_start=toml_start, **kwargs)
+        use_toml = kwargs.get("use_toml", True)
+        obj._malformed_toml_paths = (  # type: ignore[attr-defined]
+            _malformed_config_paths(toml_start) if use_toml else []
+        )
+        return obj
+
+    def describe(
+        self,
+        omit_keys: Optional[list] = None,
+        configurable: Optional[dict] = None,
+    ) -> str:
+        """Base ``describe`` plus a truthful footer for a malformed ``langstage.toml``.
+
+        The base ``HostConfig.describe`` footer says ``TOML: no langstage.toml ... found``
+        whenever no file parsed successfully — which lumps a present-but-unparseable file
+        in with a genuinely absent one, directly contradicting the ``note: ignoring
+        malformed config <path> ...`` this same command already prints on stderr (gh #86).
+        When a file WAS found on the search path but rejected as malformed, rewrite that
+        footer to say so, pointing at the stderr note instead of at "not found". A valid
+        file still shows its ``TOML read from:`` footer and genuine absence still shows
+        ``no ... found`` — both untouched.
+        """
+        text = super().describe(omit_keys=omit_keys, configurable=configurable)
+        malformed = getattr(self, "_malformed_toml_paths", [])
+        if not malformed:
+            return text
+        new_footer = (
+            "  TOML: found "
+            + ", ".join(str(p) for p in malformed)
+            + " but it is malformed (see the note above); using environment + defaults"
+        )
+        lines = text.split("\n")
+        for i, line in enumerate(lines):
+            # Only the no-file footer starts this way; a "TOML read from:" footer (some
+            # file parsed) is left alone, so a mix of a valid global + malformed project
+            # keeps crediting the file that DID load.
+            if line.startswith(_ABSENT_TOML_FOOTER_PREFIX):
+                lines[i] = new_footer
+                break
+        return "\n".join(lines)
 
 
 # Module-level constants derived from LabConfig, for call sites that read

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langstage-jupyter",
-  "version": "0.6.21",
+  "version": "0.6.22",
   "description": "JupyterLab extension with chat interface for DeepAgents",
   "keywords": [
     "jupyter",

--- a/tests/test_labconfig.py
+++ b/tests/test_labconfig.py
@@ -216,3 +216,47 @@ def test_malformed_env_keeps_the_toml_value(isolated, tmp_path, capsys, var, fie
     # the note names what it kept — the TOML value, not "default"
     err = capsys.readouterr().err
     assert "ignoring malformed" in err and str(toml_val) in err
+
+
+# ── gh #86: --show-config footer must not report a malformed langstage.toml as absent ──
+# The stderr note (from langstage-core) already says "ignoring malformed config <path>",
+# i.e. the file WAS found. But describe()'s footer keyed purely off the successfully-parsed
+# paths, so a present-but-unparseable file fell into the same "no langstage.toml ... found"
+# branch as a genuinely absent one — two contradictory statements in one command, steering
+# a user debugging "why isn't my langstage.toml applied?" at file location instead of the
+# real syntax typo. The three config states must render three distinct footers.
+
+# The issue's exact repro: a [jupyter table header missing its closing ']'.
+_MALFORMED_TOML = '[model]\nname = "my-model"\ntemperature = 0.5\n[jupyter\nvirtual_mode = false\n'
+
+
+def test_show_config_footer_flags_malformed_toml_as_found(isolated, tmp_path, capsys):
+    """Present-but-malformed: the footer must NOT say 'no ... found', and must name the
+    file as found-but-malformed — agreeing with the stderr 'ignoring malformed' note."""
+    (tmp_path / "langstage.toml").write_text(_MALFORMED_TOML)
+    text = LabConfig.resolve(env={}, toml_start=tmp_path).describe()
+
+    assert "no langstage.toml" not in text, "malformed file still reported as absent (gh #86)"
+    assert "malformed" in text, "footer should say the found file is malformed"
+    assert str(tmp_path / "langstage.toml") in text, "footer should name the found file"
+    # ...and it agrees with the stderr note langstage-core emits for the same file.
+    assert "ignoring malformed config" in capsys.readouterr().err
+
+
+def test_show_config_footer_valid_toml_still_reads(isolated, tmp_path):
+    """A VALID file still shows the normal 'TOML read from: <path>' footer (no regression)."""
+    (tmp_path / "langstage.toml").write_text('[model]\nname = "my-model"\n')
+    text = LabConfig.resolve(env={}, toml_start=tmp_path).describe()
+
+    assert "TOML read from:" in text
+    assert str(tmp_path / "langstage.toml") in text
+    assert "malformed" not in text
+    assert "no langstage.toml" not in text
+
+
+def test_show_config_footer_absent_toml_still_reports_not_found(isolated, tmp_path):
+    """Genuine absence still shows the 'no langstage.toml ... found' footer (no regression)."""
+    text = LabConfig.resolve(env={}, toml_start=tmp_path).describe()
+
+    assert "TOML: no langstage.toml (or legacy deepagents.toml) found" in text
+    assert "malformed" not in text


### PR DESCRIPTION
## Problem (gh #86)

When a `langstage.toml` is **present but has a syntax error**, `langstage-jupyter --show-config` printed two directly contradictory statements in the output of the *same* command:

- **stderr (correct):** `note: ignoring malformed config /…/langstage.toml (TOMLDecodeError: …); using environment + defaults instead.` — the file *was* found, it just couldn't be parsed.
- **stdout footer (wrong):** `TOML: no langstage.toml (or legacy deepagents.toml) found` — claims the file doesn't exist.

A present-but-unparseable file rendered **identically to no file at all**, so a user debugging "why isn't my `langstage.toml` applied?" was steered at file location / naming instead of the real cause — a syntax typo already flagged one line earlier on stderr.

## Root cause

`HostConfig.describe()`'s footer keys purely off the **successfully-parsed** paths (`_toml_paths`), which a malformed file leaves empty — collapsing it into the same `else` branch as genuine absence.

## Fix

`LabConfig` now overrides `resolve()` / `describe()`:

- `resolve()` — while `toml_start` is still in hand — stashes the config files that exist on **this** resolve's search path but failed to parse. Detection intersects langstage-core's process-global `_malformed_toml` set (the #61/#42 tracking that also emits the stderr note) with the files actually on the search path (nearest project `langstage.toml` / legacy `deepagents.toml` + the global config), so a stale entry from an unrelated resolve elsewhere in the process can't leak in.
- `describe()` reads that back and, **only when the base printed the no-file footer**, rewrites it to:

  ```
  TOML: found <path> but it is malformed (see the note above); using environment + defaults
  ```

  — now agreeing with the stderr note instead of contradicting it.

The three config states now render three distinct, truthful footers:

| State | Footer |
|---|---|
| Absent | `TOML: no langstage.toml (or legacy deepagents.toml) found` (unchanged) |
| Valid | `TOML read from: <path>` (unchanged) |
| **Present but malformed** | `TOML: found <path> but it is malformed (see the note above); using environment + defaults` (**new**) |

A mix of a valid global + malformed project keeps crediting the file that *did* load (the base `TOML read from:` footer is left alone).

## Tests

Three regression tests in `tests/test_labconfig.py` pin all three footer states, using the issue's exact repro (a `[jupyter` header missing its `]`). The malformed-case test **fails before the fix and passes after** (verified by reverting only the source and re-running: `1 failed, 2 passed`); the valid/absent tests guard against regression.

Full suite: **221 passed, 1 skipped** (baseline 218 + 3 new) on a clean/CI-equivalent tree.

Version bumped to **0.6.22** with a `CHANGELOG.md` entry.

Closes #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B